### PR TITLE
(For AlexL) Add support for GET /decisions api to sift-java client lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,16 @@ WorkflowStatusRequest request = client.buildRequest(new WorkflowStatusFieldSet()
         .setWorkflowRunId("someid"));
 ```
 
+#### Get decisions
+
+[API Docs](https://siftscience.com/developers/docs/java/decisions-api/get-decisions)
+
+To retrieve available decisions, create a request with GetDecisionsFieldSet.
+```java
+GetDecisions request = client.buildRequest(new GetDecisionsFieldSet()
+        .setAccountId("your_account_id"));
+```
+
 ### Decision Status API
 
 [API Docs](https://siftscience.com/developers/docs/java/decisions-api/decision-status)

--- a/README.md
+++ b/README.md
@@ -216,14 +216,13 @@ GetDecisions request = client.buildRequest(new GetDecisionsFieldSet()
         .setAbuseTypes(ImmutableList.of(AbuseType.PAYMENT_ABUSE, AbuseType.CONTENT_ABUSE))
 ```
 
-Pagination is also supported, with offset by creation time (`created_before`) and limit (`limit`).
+Pagination is also supported, with offset by index (`from`) and limit (`limit`).
 The default `limit` is to return up to 100 results.
+The default offset value `from` is 0.
 ```java
 GetDecisions request = client.buildRequest(new GetDecisionsFieldSet()
         .setAccountId("your_account_id"))
-        .setCreatedBefore(Instant.now()
-                                 .minus(7, ChronoUnit.WEEKS)
-                                 .getEpochSecond())
+        .setFrom(15)
         .setLimit(10);  
 ```
 

--- a/README.md
+++ b/README.md
@@ -201,19 +201,40 @@ WorkflowStatusRequest request = client.buildRequest(new WorkflowStatusFieldSet()
 
 [API Docs](https://siftscience.com/developers/docs/java/decisions-api/get-decisions)
 
-To retrieve available decisions, create a request with GetDecisionsFieldSet.
+To retrieve available decisions, build a request with a GetDecisionsFieldSet.
 ```java
 GetDecisions request = client.buildRequest(new GetDecisionsFieldSet()
         .setAbuseTypes(ImmutableList.of(AbuseType.PAYMENT_ABUSE, AbuseType.CONTENT_ABUSE))
         .setAccountId("your_account_id"));
 ```
-Additionally, this request supports filtering on results by creation time, applicable entity type, and abuse type(s). 
+
+Additionally, this field set supports filtering on results by entity and abuse type(s).
 ```java
 GetDecisions request = client.buildRequest(new GetDecisionsFieldSet()
         .setAccountId("your_account_id"))
         .setEntityType(EntityType.ORDER)
-        .setCreatedBefore(Instant.now().minus(7, ChronoUnit.WEEKS).getEpochSecond())
-        .setAbuseTypes(ImmutableList.of(AbuseType.PAYMENT_ABUSE, AbuseType.CONTENT_ABUSE));
+        .setAbuseTypes(ImmutableList.of(AbuseType.PAYMENT_ABUSE, AbuseType.CONTENT_ABUSE))
+```
+
+Pagination is also supported, with offset by creation time (`created_before`) and limit (`limit`).
+The default `limit` is to return up to 100 results.
+```java
+GetDecisions request = client.buildRequest(new GetDecisionsFieldSet()
+        .setAccountId("your_account_id"))
+        .setCreatedBefore(Instant.now()
+                                 .minus(7, ChronoUnit.WEEKS)
+                                 .getEpochSecond())
+        .setLimit(10);  
+```
+
+A request will return a paginated response if the number of query results are greater than the set `limit`. In these
+cases, the response object will contain a url (`nextRef`) at which the next set of results may be retrieved. Build a 
+new request from this `nextRef`, as follows:
+```java
+GetDecisionsResponse response = request.send();
+String nextRef = response.getBody().getNextRef();
+GetDecisionsRequest nextRequest = client.buildRequest(GetDecisionsFieldSet.fromNextRef(nextRef));
+
 ```
 
 ### Decision Status API

--- a/README.md
+++ b/README.md
@@ -204,7 +204,16 @@ WorkflowStatusRequest request = client.buildRequest(new WorkflowStatusFieldSet()
 To retrieve available decisions, create a request with GetDecisionsFieldSet.
 ```java
 GetDecisions request = client.buildRequest(new GetDecisionsFieldSet()
+        .setAbuseTypes(ImmutableList.of(AbuseType.PAYMENT_ABUSE, AbuseType.CONTENT_ABUSE))
         .setAccountId("your_account_id"));
+```
+Additionally, this request supports filtering on results by creation time, applicable entity type, and abuse type(s). 
+```java
+GetDecisions request = client.buildRequest(new GetDecisionsFieldSet()
+        .setAccountId("your_account_id"))
+        .setEntityType(EntityType.ORDER)
+        .setCreatedBefore(Instant.now().minus(7, ChronoUnit.WEEKS).getEpochSecond())
+        .setAbuseTypes(ImmutableList.of(AbuseType.PAYMENT_ABUSE, AbuseType.CONTENT_ABUSE));
 ```
 
 ### Decision Status API

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.skyscreamer', name: 'jsonassert', version: '1.3.0'
     testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.4.1'
+    compile group: 'com.google.guava', name: 'guava', version:'13.0.1'
     compile 'com.google.code.gson:gson:2.7'
     compile 'com.squareup.okhttp3:okhttp:3.4.1'
     compile 'com.squareup.okio:okio:1.9.0'

--- a/src/main/java/com/siftscience/GetDecisionsRequest.java
+++ b/src/main/java/com/siftscience/GetDecisionsRequest.java
@@ -4,18 +4,37 @@ import com.siftscience.model.GetDecisionFieldSet;
 import okhttp3.*;
 
 import java.io.IOException;
+import com.google.common.base.Joiner;
+
 
 public class GetDecisionsRequest extends SiftRequest<GetDecisionsResponse> {
+    private final Joiner joiner = Joiner.on(",");
+
     GetDecisionsRequest(HttpUrl baseUrl, OkHttpClient okClient, FieldSet fields) {
         super(baseUrl, okClient, fields);
     }
 
     @Override
     protected HttpUrl path(HttpUrl baseUrl) {
-        return baseUrl.newBuilder("/v3/accounts")
-                .addPathSegment(((GetDecisionFieldSet) fieldSet).getAccountId())
-                .addPathSegment("decisions")
-                .build();
+        GetDecisionFieldSet fieldSet = (GetDecisionFieldSet) this.fieldSet;
+        HttpUrl.Builder path = baseUrl.newBuilder("/v3/accounts")
+                .addPathSegment(fieldSet.getAccountId())
+                .addPathSegment("decisions");
+
+        if (fieldSet.getEntityType() != null) {
+            path.addQueryParameter("entity_type", fieldSet.getEntityType().name());
+        }
+        if (fieldSet.getLimit() != null) {
+            path.addQueryParameter("limit", String.valueOf(fieldSet.getLimit()));
+        }
+        if (fieldSet.getCreatedBefore() != null) {
+            path.addQueryParameter("created_before", String.valueOf(fieldSet.getCreatedBefore()));
+        }
+        if (fieldSet.getAbuseTypes() != null && !fieldSet.getAbuseTypes().isEmpty()) {
+            path.addQueryParameter("abuse_types", joiner.join(fieldSet.getAbuseTypes()));
+        }
+
+        return path.build();
     }
 
     @Override

--- a/src/main/java/com/siftscience/GetDecisionsRequest.java
+++ b/src/main/java/com/siftscience/GetDecisionsRequest.java
@@ -21,7 +21,7 @@ public class GetDecisionsRequest extends SiftRequest<GetDecisionsResponse> {
     public enum Query {
         ENTITY_TYPE("entity_type"),
         LIMIT("limit"),
-        CREATED_BEFORE("created_before"),
+        FROM("from"),
         ABUSE_TYPES("abuse_types");
 
         private final String value;
@@ -49,8 +49,8 @@ public class GetDecisionsRequest extends SiftRequest<GetDecisionsResponse> {
         if (fieldSet.getLimit() != null) {
             path.addQueryParameter(Query.LIMIT.toString(), String.valueOf(fieldSet.getLimit()));
         }
-        if (fieldSet.getCreatedBefore() != null) {
-            path.addQueryParameter(Query.CREATED_BEFORE.toString(), String.valueOf(fieldSet.getCreatedBefore()));
+        if (fieldSet.getFrom() != null) {
+            path.addQueryParameter(Query.FROM.toString(), String.valueOf(fieldSet.getFrom()));
         }
         if (fieldSet.getAbuseTypes() != null && !fieldSet.getAbuseTypes().isEmpty()) {
             path.addQueryParameter(Query.ABUSE_TYPES.toString(), joiner.join(fieldSet.getAbuseTypes()));

--- a/src/main/java/com/siftscience/GetDecisionsRequest.java
+++ b/src/main/java/com/siftscience/GetDecisionsRequest.java
@@ -18,6 +18,24 @@ public class GetDecisionsRequest extends SiftRequest<GetDecisionsResponse> {
         super(baseUrl, okClient, fields);
     }
 
+    public enum Query {
+        ENTITY_TYPE("entity_type"),
+        LIMIT("limit"),
+        CREATED_BEFORE("created_before"),
+        ABUSE_TYPES("abuse_types");
+
+        private final String value;
+
+        Query(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+    }
+
     @Override
     protected HttpUrl path(HttpUrl baseUrl) {
         GetDecisionFieldSet fieldSet = (GetDecisionFieldSet) this.fieldSet;
@@ -26,16 +44,16 @@ public class GetDecisionsRequest extends SiftRequest<GetDecisionsResponse> {
                 .addPathSegment("decisions");
 
         if (fieldSet.getEntityType() != null) {
-            path.addQueryParameter("entity_type", fieldSet.getEntityType().name());
+            path.addQueryParameter(Query.ENTITY_TYPE.toString(), fieldSet.getEntityType().name());
         }
         if (fieldSet.getLimit() != null) {
-            path.addQueryParameter("limit", String.valueOf(fieldSet.getLimit()));
+            path.addQueryParameter(Query.LIMIT.toString(), String.valueOf(fieldSet.getLimit()));
         }
         if (fieldSet.getCreatedBefore() != null) {
-            path.addQueryParameter("created_before", String.valueOf(fieldSet.getCreatedBefore()));
+            path.addQueryParameter(Query.CREATED_BEFORE.toString(), String.valueOf(fieldSet.getCreatedBefore()));
         }
         if (fieldSet.getAbuseTypes() != null && !fieldSet.getAbuseTypes().isEmpty()) {
-            path.addQueryParameter("abuse_types", joiner.join(fieldSet.getAbuseTypes()));
+            path.addQueryParameter(Query.ABUSE_TYPES.toString(), joiner.join(fieldSet.getAbuseTypes()));
         }
 
         return path.build();

--- a/src/main/java/com/siftscience/GetDecisionsRequest.java
+++ b/src/main/java/com/siftscience/GetDecisionsRequest.java
@@ -1,10 +1,14 @@
 package com.siftscience;
 
 import com.siftscience.model.GetDecisionFieldSet;
-import okhttp3.*;
 
 import java.io.IOException;
 import com.google.common.base.Joiner;
+import okhttp3.Credentials;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
 
 
 public class GetDecisionsRequest extends SiftRequest<GetDecisionsResponse> {

--- a/src/main/java/com/siftscience/GetDecisionsRequest.java
+++ b/src/main/java/com/siftscience/GetDecisionsRequest.java
@@ -1,0 +1,32 @@
+package com.siftscience;
+
+import com.siftscience.model.GetDecisionFieldSet;
+import okhttp3.*;
+
+import java.io.IOException;
+
+public class GetDecisionsRequest extends SiftRequest<GetDecisionsResponse> {
+    GetDecisionsRequest(HttpUrl baseUrl, OkHttpClient okClient, FieldSet fields) {
+        super(baseUrl, okClient, fields);
+    }
+
+    @Override
+    protected HttpUrl path(HttpUrl baseUrl) {
+        return baseUrl.newBuilder("/v3/accounts")
+                .addPathSegment(((GetDecisionFieldSet) fieldSet).getAccountId())
+                .addPathSegment("decisions")
+                .build();
+    }
+
+    @Override
+    GetDecisionsResponse buildResponse(Response response, FieldSet requestFields)
+            throws IOException {
+        return new GetDecisionsResponse(response, requestFields);
+    }
+
+    @Override
+    protected void modifyRequestBuilder(Request.Builder builder) {
+        super.modifyRequestBuilder(builder);
+        builder.header("Authorization", Credentials.basic(fieldSet.getApiKey(), "")).get();
+    }
+}

--- a/src/main/java/com/siftscience/GetDecisionsResponse.java
+++ b/src/main/java/com/siftscience/GetDecisionsResponse.java
@@ -1,0 +1,23 @@
+package com.siftscience;
+
+import com.siftscience.SiftRequest;
+import com.siftscience.model.GetDecisionsResponseBody;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Response;
+
+import java.io.IOException;
+
+import static com.siftscience.FieldSet.gson;
+
+public class GetDecisionsResponse extends SiftResponse<GetDecisionsResponseBody>{
+
+    public GetDecisionsResponse(Response okResponse, FieldSet requestBody) throws IOException {
+        super(okResponse, requestBody);
+    }
+
+    @Override
+    void populateBodyFromJson(String jsonBody) {
+        body = gson.fromJson(jsonBody, GetDecisionsResponseBody.class);
+    }
+}

--- a/src/main/java/com/siftscience/GetDecisionsResponse.java
+++ b/src/main/java/com/siftscience/GetDecisionsResponse.java
@@ -1,16 +1,13 @@
 package com.siftscience;
 
-import com.siftscience.SiftRequest;
 import com.siftscience.model.GetDecisionsResponseBody;
-import okhttp3.HttpUrl;
-import okhttp3.OkHttpClient;
 import okhttp3.Response;
 
 import java.io.IOException;
 
 import static com.siftscience.FieldSet.gson;
 
-public class GetDecisionsResponse extends SiftResponse<GetDecisionsResponseBody>{
+public class GetDecisionsResponse extends SiftResponse<GetDecisionsResponseBody> {
 
     public GetDecisionsResponse(Response okResponse, FieldSet requestBody) throws IOException {
         super(okResponse, requestBody);

--- a/src/main/java/com/siftscience/SiftClient.java
+++ b/src/main/java/com/siftscience/SiftClient.java
@@ -52,6 +52,11 @@ public class SiftClient {
         return new EventRequest(baseUrl, okClient, fields);
     }
 
+    public GetDecisionsRequest buildRequest(GetDecisionFieldSet fields) {
+        setupApiKey(fields);
+        return new GetDecisionsRequest(baseApi3Url, okClient, fields);
+    }
+
     public DecisionStatusRequest buildRequest(DecisionStatusFieldSet fields) {
         setupApiKey(fields);
         return new DecisionStatusRequest(baseApi3Url, okClient, fields);

--- a/src/main/java/com/siftscience/model/DecisionStatusFieldSet.java
+++ b/src/main/java/com/siftscience/model/DecisionStatusFieldSet.java
@@ -4,11 +4,11 @@ import com.siftscience.FieldSet;
 
 public class DecisionStatusFieldSet extends FieldSet<DecisionStatusFieldSet> {
 
-        public static final String ENTITY_USERS = "users";
-        public static final String ENTITY_ORDERS = "orders";
+    public static final String ENTITY_USERS = "users";
+    public static final String ENTITY_ORDERS = "orders";
 
-        private String accountId;
-        private String entity;
+    private String accountId;
+    private String entity;
     private String entityId;
 
     public String getAccountId() {

--- a/src/main/java/com/siftscience/model/DecisionStatusFieldSet.java
+++ b/src/main/java/com/siftscience/model/DecisionStatusFieldSet.java
@@ -4,11 +4,11 @@ import com.siftscience.FieldSet;
 
 public class DecisionStatusFieldSet extends FieldSet<DecisionStatusFieldSet> {
 
-    public static final String ENTITY_USERS = "users";
-    public static final String ENTITY_ORDERS = "orders";
+        public static final String ENTITY_USERS = "users";
+        public static final String ENTITY_ORDERS = "orders";
 
-    private String accountId;
-    private String entity;
+        private String accountId;
+        private String entity;
     private String entityId;
 
     public String getAccountId() {

--- a/src/main/java/com/siftscience/model/GetDecisionFieldSet.java
+++ b/src/main/java/com/siftscience/model/GetDecisionFieldSet.java
@@ -2,6 +2,8 @@ package com.siftscience.model;
 
 import com.siftscience.FieldSet;
 
+import java.util.List;
+
 public class GetDecisionFieldSet extends FieldSet<GetDecisionFieldSet> {
     public GetDecisionFieldSet() {}
 
@@ -9,19 +11,40 @@ public class GetDecisionFieldSet extends FieldSet<GetDecisionFieldSet> {
         return gson.fromJson(json, GetDecisionFieldSet.class);
     }
 
-    public static final String ENTITY_USERS = "users";
-    public static final String ENTITY_ORDERS = "orders";
-
     private String accountId;
-    private String entity;
+    private Integer limit;
+    private Long createdBefore;
+    private EntityType entityType;
+    private List<AbuseType> abuseTypes;
+
+    public enum AbuseType {
+        PAYMENT_ABUSE, CONTENT_ABUSE, PROMOTION_ABUSE, ACCOUNT_ABUSE, LEGACY, ACCOUNT_TAKEOVER
+    }
+    public enum EntityType {USER, ORDER}
+    public enum DecisionCategory {BLOCK, WATCH, ACCEPT}
 
     public GetDecisionFieldSet setAccountId(String accountId) {
         this.accountId = accountId;
         return this;
     }
 
-    public GetDecisionFieldSet setEntity(String entity) {
-        this.entity = entity;
+    public GetDecisionFieldSet setLimit(Integer limit) {
+        this.limit = limit;
+        return this;
+    }
+
+    public GetDecisionFieldSet setCreatedBefore(Long createdBefore) {
+        this.createdBefore = createdBefore;
+        return this;
+    }
+
+    public GetDecisionFieldSet setEntityType(EntityType entityType) {
+        this.entityType = entityType;
+        return this;
+    }
+
+    public GetDecisionFieldSet setAbuseTypes(List<AbuseType> abuseTypes) {
+        this.abuseTypes = abuseTypes;
         return this;
     }
 
@@ -29,7 +52,19 @@ public class GetDecisionFieldSet extends FieldSet<GetDecisionFieldSet> {
         return accountId;
     }
 
-    public String getEntity() {
-        return entity;
+    public Integer getLimit() {
+        return limit;
+    }
+
+    public Long getCreatedBefore() {
+        return createdBefore;
+    }
+
+    public EntityType getEntityType() {
+        return entityType;
+    }
+
+    public List<AbuseType> getAbuseTypes() {
+        return abuseTypes;
     }
 }

--- a/src/main/java/com/siftscience/model/GetDecisionFieldSet.java
+++ b/src/main/java/com/siftscience/model/GetDecisionFieldSet.java
@@ -1,21 +1,79 @@
 package com.siftscience.model;
 
+import com.google.common.collect.ImmutableList;
 import com.siftscience.FieldSet;
+import com.siftscience.exception.InvalidFieldException;
+import com.siftscience.exception.InvalidRequestException;
 
+import java.net.URI;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.siftscience.GetDecisionsRequest.*;
 
 public class GetDecisionFieldSet extends FieldSet<GetDecisionFieldSet> {
+    private String accountId;
+    private Integer limit;
+    private Long createdBefore;
+    private EntityType entityType;
+    private List<AbuseType> abuseTypes;
+    private static final Pattern ACCOUNT_ID_PATTERN = Pattern.compile("(?<=accounts/)\\d+[^/]");
+
     public GetDecisionFieldSet() {}
 
     public static GetDecisionFieldSet fromJson(String json) {
         return gson.fromJson(json, GetDecisionFieldSet.class);
     }
 
-    private String accountId;
-    private Integer limit;
-    private Long createdBefore;
-    private EntityType entityType;
-    private List<AbuseType> abuseTypes;
+    public static GetDecisionFieldSet fromNextRef(String nextRef) {
+        URI uri = URI.create(nextRef);
+        String queries = uri.getQuery();
+            if ( queries == null || queries.isEmpty()) {
+            throw new InvalidRequestException("Invalid format for nextRef " + nextRef);
+        } else {
+            GetDecisionFieldSet fieldSet = new GetDecisionFieldSet();
+                Matcher matcher = ACCOUNT_ID_PATTERN.matcher(uri.getPath());
+                if (matcher.find()) {
+                    fieldSet.setAccountId(matcher.group());
+                } else {
+                    throw new InvalidFieldException("Unable to parse accountId from ref " +
+                            nextRef);
+                }
+            for (String query : queries.split("&")) {
+                String[] pair = query.split("=");
+                if (pair.length == 2) {
+                    switch (Query.valueOf(pair[0].toUpperCase())) {
+                        case ABUSE_TYPES:
+                            fieldSet.setAbuseTypes(pair[1]);
+                            break;
+                        case CREATED_BEFORE:
+                            fieldSet.setCreatedBefore(Long.parseLong(pair[1]));
+                            break;
+                        case ENTITY_TYPE:
+                            fieldSet.setEntityType(EntityType.valueOf(pair[1].toUpperCase()));
+                            break;
+                        case LIMIT:
+                            fieldSet.setLimit(Integer.valueOf(pair[1]));
+                            break;
+                        default:
+                            break;
+                    }
+                } else {
+                    throw new InvalidFieldException("Invalid query " + query);
+                }
+            }
+            return fieldSet;
+        }
+    }
+
+    private void setAbuseTypes(String abuseTypeCsv) {
+        ImmutableList.Builder<AbuseType> abuseTypes = ImmutableList.builder();
+        for (String abuseType : abuseTypeCsv.split(",")) {
+            abuseTypes.add(AbuseType.valueOf(abuseType.toUpperCase()));
+        }
+        this.abuseTypes = abuseTypes.build();
+    }
 
     public enum AbuseType {
         PAYMENT_ABUSE, CONTENT_ABUSE, PROMOTION_ABUSE, ACCOUNT_ABUSE, LEGACY, ACCOUNT_TAKEOVER

--- a/src/main/java/com/siftscience/model/GetDecisionFieldSet.java
+++ b/src/main/java/com/siftscience/model/GetDecisionFieldSet.java
@@ -15,7 +15,7 @@ import static com.siftscience.GetDecisionsRequest.*;
 public class GetDecisionFieldSet extends FieldSet<GetDecisionFieldSet> {
     private String accountId;
     private Integer limit;
-    private Long createdBefore;
+    private Integer from;
     private EntityType entityType;
     private List<AbuseType> abuseTypes;
     private static final Pattern ACCOUNT_ID_PATTERN = Pattern.compile("(?<=accounts/)\\d+[^/]");
@@ -47,11 +47,11 @@ public class GetDecisionFieldSet extends FieldSet<GetDecisionFieldSet> {
                         case ABUSE_TYPES:
                             fieldSet.setAbuseTypes(pair[1]);
                             break;
-                        case CREATED_BEFORE:
-                            fieldSet.setCreatedBefore(Long.parseLong(pair[1]));
-                            break;
                         case ENTITY_TYPE:
                             fieldSet.setEntityType(EntityType.valueOf(pair[1].toUpperCase()));
+                            break;
+                        case FROM:
+                            fieldSet.setFrom(Integer.valueOf(pair[1]));
                             break;
                         case LIMIT:
                             fieldSet.setLimit(Integer.valueOf(pair[1]));
@@ -91,8 +91,8 @@ public class GetDecisionFieldSet extends FieldSet<GetDecisionFieldSet> {
         return this;
     }
 
-    public GetDecisionFieldSet setCreatedBefore(Long createdBefore) {
-        this.createdBefore = createdBefore;
+    public GetDecisionFieldSet setFrom(Integer from) {
+        this.from = from;
         return this;
     }
 
@@ -114,8 +114,8 @@ public class GetDecisionFieldSet extends FieldSet<GetDecisionFieldSet> {
         return limit;
     }
 
-    public Long getCreatedBefore() {
-        return createdBefore;
+    public Integer getFrom() {
+        return from;
     }
 
     public EntityType getEntityType() {

--- a/src/main/java/com/siftscience/model/GetDecisionFieldSet.java
+++ b/src/main/java/com/siftscience/model/GetDecisionFieldSet.java
@@ -1,0 +1,35 @@
+package com.siftscience.model;
+
+import com.siftscience.FieldSet;
+
+public class GetDecisionFieldSet extends FieldSet<GetDecisionFieldSet> {
+    public GetDecisionFieldSet() {}
+
+    public static GetDecisionFieldSet fromJson(String json) {
+        return gson.fromJson(json, GetDecisionFieldSet.class);
+    }
+
+    public static final String ENTITY_USERS = "users";
+    public static final String ENTITY_ORDERS = "orders";
+
+    private String accountId;
+    private String entity;
+
+    public GetDecisionFieldSet setAccountId(String accountId) {
+        this.accountId = accountId;
+        return this;
+    }
+
+    public GetDecisionFieldSet setEntity(String entity) {
+        this.entity = entity;
+        return this;
+    }
+
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public String getEntity() {
+        return entity;
+    }
+}

--- a/src/main/java/com/siftscience/model/GetDecisionsResponseBody.java
+++ b/src/main/java/com/siftscience/model/GetDecisionsResponseBody.java
@@ -37,7 +37,7 @@ public class GetDecisionsResponseBody extends BaseResponseBody<GetDecisionsRespo
         return nextRef;
     }
 
-    class Decision {
+    public class Decision {
         @Expose @SerializedName("id") private final String id;
         @Expose @SerializedName("name") private final String name;
         @Expose @SerializedName("description") private final String description;
@@ -64,6 +64,50 @@ public class GetDecisionsResponseBody extends BaseResponseBody<GetDecisionsRespo
             this.createdBy = createdBy;
             this.updatedAt = updatedAt;
             this.updatedBy = updatedBy;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public DecisionCategory getCategory() {
+            return category;
+        }
+
+        public EntityType getEntityType() {
+            return entityType;
+        }
+
+        public AbuseType getAbuseType() {
+            return abuseType;
+        }
+
+        public String getWebhookUrl() {
+            return webhookUrl;
+        }
+
+        public Long getCreatedAt() {
+            return createdAt;
+        }
+
+        public String getCreatedBy() {
+            return createdBy;
+        }
+
+        public Long getUpdatedAt() {
+            return updatedAt;
+        }
+
+        public String getUpdatedBy() {
+            return updatedBy;
         }
     }
 }

--- a/src/main/java/com/siftscience/model/GetDecisionsResponseBody.java
+++ b/src/main/java/com/siftscience/model/GetDecisionsResponseBody.java
@@ -9,8 +9,8 @@ import static com.siftscience.model.GetDecisionFieldSet.*;
 
 public class GetDecisionsResponseBody extends BaseResponseBody<GetDecisionsResponseBody>{
     @Expose @SerializedName("data") private final List<Decision> decisions;
-    @Expose @SerializedName("has_more") private final boolean hasMore;
-    @Expose @SerializedName("total_results") private final long totalResults;
+    @Expose @SerializedName("has_more") private final Boolean hasMore;
+    @Expose @SerializedName("total_results") private final Long totalResults;
     @Expose @SerializedName("next_ref") private final String nextRef;
 
 
@@ -25,11 +25,11 @@ public class GetDecisionsResponseBody extends BaseResponseBody<GetDecisionsRespo
         return decisions;
     }
 
-    public boolean isHasMore() {
+    public Boolean isHasMore() {
         return hasMore;
     }
 
-    public long getTotalResults() {
+    public Long getTotalResults() {
         return totalResults;
     }
 
@@ -45,9 +45,9 @@ public class GetDecisionsResponseBody extends BaseResponseBody<GetDecisionsRespo
         @Expose @SerializedName("entity_type") private final EntityType entityType;
         @Expose @SerializedName("abuse_type") private final AbuseType abuseType;
         @Expose @SerializedName("webhook_url") private final String webhookUrl;
-        @Expose @SerializedName("created_at") private final long createdAt;
+        @Expose @SerializedName("created_at") private final Long createdAt;
         @Expose @SerializedName("created_by") private final String createdBy;
-        @Expose @SerializedName("updated_at") private final long updatedAt;
+        @Expose @SerializedName("updated_at") private final Long updatedAt;
         @Expose @SerializedName("updated_by") private final String updatedBy;
 
         public Decision(String id, String name, String description, DecisionCategory category,

--- a/src/main/java/com/siftscience/model/GetDecisionsResponseBody.java
+++ b/src/main/java/com/siftscience/model/GetDecisionsResponseBody.java
@@ -1,0 +1,14 @@
+package com.siftscience.model;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+public class GetDecisionsResponseBody extends BaseResponseBody<GetDecisionsResponseBody>{
+    @Expose @SerializedName("decisions") private final List<Decision> decisions;
+
+    public GetDecisionsResponseBody(List<Decision> decisions) {
+        this.decisions = decisions;
+    }
+}

--- a/src/main/java/com/siftscience/model/GetDecisionsResponseBody.java
+++ b/src/main/java/com/siftscience/model/GetDecisionsResponseBody.java
@@ -5,10 +5,65 @@ import com.google.gson.annotations.SerializedName;
 
 import java.util.List;
 
-public class GetDecisionsResponseBody extends BaseResponseBody<GetDecisionsResponseBody>{
-    @Expose @SerializedName("decisions") private final List<Decision> decisions;
+import static com.siftscience.model.GetDecisionFieldSet.*;
 
-    public GetDecisionsResponseBody(List<Decision> decisions) {
+public class GetDecisionsResponseBody extends BaseResponseBody<GetDecisionsResponseBody>{
+    @Expose @SerializedName("data") private final List<Decision> decisions;
+    @Expose @SerializedName("has_more") private final boolean hasMore;
+    @Expose @SerializedName("total_results") private final long totalResults;
+    @Expose @SerializedName("next_ref") private final String nextRef;
+
+
+    public GetDecisionsResponseBody(List<Decision> decisions, boolean hasMore, long totalResults, String nextRef) {
         this.decisions = decisions;
+        this.hasMore = hasMore;
+        this.totalResults = totalResults;
+        this.nextRef = nextRef;
+    }
+
+    public List<Decision> getDecisions() {
+        return decisions;
+    }
+
+    public boolean isHasMore() {
+        return hasMore;
+    }
+
+    public long getTotalResults() {
+        return totalResults;
+    }
+
+    public String getNextRef() {
+        return nextRef;
+    }
+
+    class Decision {
+        @Expose @SerializedName("id") private final String id;
+        @Expose @SerializedName("name") private final String name;
+        @Expose @SerializedName("description") private final String description;
+        @Expose @SerializedName("category") private final DecisionCategory category;
+        @Expose @SerializedName("entity_type") private final EntityType entityType;
+        @Expose @SerializedName("abuse_type") private final AbuseType abuseType;
+        @Expose @SerializedName("webhook_url") private final String webhookUrl;
+        @Expose @SerializedName("created_at") private final long createdAt;
+        @Expose @SerializedName("created_by") private final String createdBy;
+        @Expose @SerializedName("updated_at") private final long updatedAt;
+        @Expose @SerializedName("updated_by") private final String updatedBy;
+
+        public Decision(String id, String name, String description, DecisionCategory category,
+                        EntityType entityType, AbuseType abuseType, String webhookUrl,
+                        long createdAt, String createdBy, long updatedAt, String updatedBy) {
+            this.id = id;
+            this.name = name;
+            this.description = description;
+            this.category = category;
+            this.entityType = entityType;
+            this.abuseType = abuseType;
+            this.webhookUrl = webhookUrl;
+            this.createdAt = createdAt;
+            this.createdBy = createdBy;
+            this.updatedAt = updatedAt;
+            this.updatedBy = updatedBy;
+        }
     }
 }

--- a/src/test/java/com/siftscience/GetDecisionsTest.java
+++ b/src/test/java/com/siftscience/GetDecisionsTest.java
@@ -20,8 +20,9 @@ public class GetDecisionsTest {
     @Test
     public void testDecisionStatus() throws Exception {
         long createdBefore = System.currentTimeMillis();
-        String accountId = "your_account_id";
+        String accountId = "8675308";
 
+        long lastCreated = System.currentTimeMillis();
         String responseBody = "{" +
                 "   \"data\": [" +
                 "       {" +
@@ -41,7 +42,8 @@ public class GetDecisionsTest {
                 "   \"has_more\": false," +
                 "   \"total_results\": 3," +
                 "   \"next_ref\": \"/v3/accounts/" + accountId + "/decisions?created_before=" +
-                        createdBefore + "\"" +
+                lastCreated + "&abuse_types=CONTENT_ABUSE,PAYMENT_ABUSE" +
+                        "&entity_type=user&limit=11\"" +
                 "}";
 
 
@@ -73,14 +75,18 @@ public class GetDecisionsTest {
         // Verify the request.
         RecordedRequest request = server.takeRequest();
         Assert.assertEquals("GET", request.getMethod());
-        Assert.assertEquals("/v3/accounts/your_account_id/decisions?entity_type=ORDER&limit=11" +
+        Assert.assertEquals("/v3/accounts/" + accountId + "/decisions?entity_type=ORDER&limit=11" +
                 "&created_before="+createdBefore+"&abuse_types=ACCOUNT_ABUSE,ACCOUNT_TAKEOVER",
                 request.getPath());
         Assert.assertEquals(request.getHeader("Authorization"), "Basic eW91cl9hcGlfa2V5Og==");
+
 
         // Verify the response was parsed correctly.
         Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
         JSONAssert.assertEquals(response.getBody().readUtf8(),
                 siftResponse.getBody().toJson(), true);
+
+        GetDecisionsRequest nextRequest = client.buildRequest(GetDecisionFieldSet.fromNextRef(
+                siftResponse.getBody().getNextRef()));
     }
 }

--- a/src/test/java/com/siftscience/GetDecisionsTest.java
+++ b/src/test/java/com/siftscience/GetDecisionsTest.java
@@ -19,10 +19,7 @@ public class GetDecisionsTest {
     
     @Test
     public void testDecisionStatus() throws Exception {
-        long createdBefore = System.currentTimeMillis();
         String accountId = "8675308";
-
-        long lastCreated = System.currentTimeMillis();
         String responseBody = "{" +
                 "   \"data\": [" +
                 "       {" +
@@ -41,9 +38,11 @@ public class GetDecisionsTest {
                 "   ]," +
                 "   \"has_more\": false," +
                 "   \"total_results\": 3," +
-                "   \"next_ref\": \"/v3/accounts/" + accountId + "/decisions?created_before=" +
-                lastCreated + "&abuse_types=CONTENT_ABUSE,PAYMENT_ABUSE" +
-                        "&entity_type=user&limit=11\"" +
+                "   \"next_ref\": \"/v3/accounts/" + accountId + "/decisions" +
+                        "?abuse_types=CONTENT_ABUSE,PAYMENT_ABUSE" +
+                        "&entity_type=user" +
+                        "&from=12" +
+                        "&limit=11\"" +
                 "}";
 
 
@@ -66,7 +65,7 @@ public class GetDecisionsTest {
                 .setAccountId(accountId)
                 .setLimit(11)
                 .setAbuseTypes(Lists.newArrayList(ACCOUNT_ABUSE, ACCOUNT_TAKEOVER))
-                .setCreatedBefore(createdBefore)
+                .setFrom(1)
                 .setEntityType(ORDER)
 
         );
@@ -76,7 +75,7 @@ public class GetDecisionsTest {
         RecordedRequest request = server.takeRequest();
         Assert.assertEquals("GET", request.getMethod());
         Assert.assertEquals("/v3/accounts/" + accountId + "/decisions?entity_type=ORDER&limit=11" +
-                "&created_before="+createdBefore+"&abuse_types=ACCOUNT_ABUSE,ACCOUNT_TAKEOVER",
+                "&from=1&abuse_types=ACCOUNT_ABUSE,ACCOUNT_TAKEOVER",
                 request.getPath());
         Assert.assertEquals(request.getHeader("Authorization"), "Basic eW91cl9hcGlfa2V5Og==");
 

--- a/src/test/java/com/siftscience/GetDecisionsTest.java
+++ b/src/test/java/com/siftscience/GetDecisionsTest.java
@@ -1,0 +1,56 @@
+package com.siftscience;
+
+import com.siftscience.model.GetDecisionFieldSet;
+import okhttp3.HttpUrl;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import static java.net.HttpURLConnection.HTTP_OK;
+
+public class GetDecisionsTest {
+    @Test
+    public void testDecisionStatus() throws Exception {
+        String responseBody = "{\"decisions\": " +
+                    "[" +
+                        "{\"id\":\"user_is_good\"}," +
+                        "{\"id\":\"user_is_bad\"}," +
+                        "{\"id\":\"user_is_ugly\"}" +
+                    "]" +
+                "}";
+
+
+        MockWebServer server = new MockWebServer();
+        MockResponse response = new MockResponse();
+        response.setResponseCode(HTTP_OK);
+
+        response.setBody(responseBody);
+        server.enqueue(response);
+        server.start();
+        HttpUrl baseUrl;
+        baseUrl = server.url("");
+
+        // Create a new client and link it to the mock server.
+        SiftClient client = new SiftClient("your_api_key");
+        client.setBaseApi3Url(baseUrl);
+
+        // Build and execute the request against the mock server.
+        GetDecisionsRequest getDecisionsRequest = client.buildRequest(
+                new GetDecisionFieldSet().setAccountId("your_account_id"));
+        GetDecisionsResponse siftResponse = getDecisionsRequest.send();
+
+        // Verify the request.
+        RecordedRequest request = server.takeRequest();
+        Assert.assertEquals("GET", request.getMethod());
+        Assert.assertEquals("/v3/accounts/your_account_id/decisions", request.getPath());
+        Assert.assertEquals(request.getHeader("Authorization"), "Basic eW91cl9hcGlfa2V5Og==");
+
+        // Verify the response was parsed correctly.
+        Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
+        JSONAssert.assertEquals(response.getBody().readUtf8(),
+                siftResponse.getBody().toJson(), true);
+    }
+}

--- a/src/test/java/com/siftscience/GetDecisionsTest.java
+++ b/src/test/java/com/siftscience/GetDecisionsTest.java
@@ -1,5 +1,6 @@
 package com.siftscience;
 
+import com.google.common.collect.Lists;
 import com.siftscience.model.GetDecisionFieldSet;
 import okhttp3.HttpUrl;
 import okhttp3.mockwebserver.MockResponse;
@@ -9,17 +10,38 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
+import static com.siftscience.model.GetDecisionFieldSet.AbuseType.ACCOUNT_ABUSE;
+import static com.siftscience.model.GetDecisionFieldSet.AbuseType.ACCOUNT_TAKEOVER;
+import static com.siftscience.model.GetDecisionFieldSet.EntityType.ORDER;
 import static java.net.HttpURLConnection.HTTP_OK;
 
 public class GetDecisionsTest {
+    
     @Test
     public void testDecisionStatus() throws Exception {
-        String responseBody = "{\"decisions\": " +
-                    "[" +
-                        "{\"id\":\"user_is_good\"}," +
-                        "{\"id\":\"user_is_bad\"}," +
-                        "{\"id\":\"user_is_ugly\"}" +
-                    "]" +
+        long createdBefore = System.currentTimeMillis();
+        String accountId = "your_account_id";
+
+        String responseBody = "{" +
+                "   \"data\": [" +
+                "       {" +
+                "           \"id\": \"user_is_good\"," +
+                "           \"name\": \"User is good\"," +
+                "           \"description\": \"likely a good user\"," +
+                "           \"category\": \"ACCEPT\"," +
+                "           \"entity_type\": \"USER\"," +
+                "           \"abuse_type\": \"LEGACY\"," +
+                "           \"webhook_url\": \"\"," +
+                "           \"created_at\": 123," +
+                "           \"created_by\": \"clint@biz.com\"," +
+                "           \"updated_at\": 234," +
+                "           \"updated_by\":\"clint@biz.com\"" +
+                "       }" +
+                "   ]," +
+                "   \"has_more\": false," +
+                "   \"total_results\": 3," +
+                "   \"next_ref\": \"/v3/accounts/" + accountId + "/decisions?created_before=" +
+                        createdBefore + "\"" +
                 "}";
 
 
@@ -38,14 +60,22 @@ public class GetDecisionsTest {
         client.setBaseApi3Url(baseUrl);
 
         // Build and execute the request against the mock server.
-        GetDecisionsRequest getDecisionsRequest = client.buildRequest(
-                new GetDecisionFieldSet().setAccountId("your_account_id"));
+        GetDecisionsRequest getDecisionsRequest = client.buildRequest(new GetDecisionFieldSet()
+                .setAccountId(accountId)
+                .setLimit(11)
+                .setAbuseTypes(Lists.newArrayList(ACCOUNT_ABUSE, ACCOUNT_TAKEOVER))
+                .setCreatedBefore(createdBefore)
+                .setEntityType(ORDER)
+
+        );
         GetDecisionsResponse siftResponse = getDecisionsRequest.send();
 
         // Verify the request.
         RecordedRequest request = server.takeRequest();
         Assert.assertEquals("GET", request.getMethod());
-        Assert.assertEquals("/v3/accounts/your_account_id/decisions", request.getPath());
+        Assert.assertEquals("/v3/accounts/your_account_id/decisions?entity_type=ORDER&limit=11" +
+                "&created_before="+createdBefore+"&abuse_types=ACCOUNT_ABUSE,ACCOUNT_TAKEOVER",
+                request.getPath());
         Assert.assertEquals(request.getHeader("Authorization"), "Basic eW91cl9hcGlfa2V5Og==");
 
         // Verify the response was parsed correctly.


### PR DESCRIPTION
Description:

This PR will update the java client to reflect the public decisions API `GET /decisions` endpoint.

Changes:
* Add GetDecisionsRequest/Response test
* Add to SiftClient
* update README.md with /GET decisions

Test:
* Unit tests
* client tests

Deployment:

As outlined here: https://paper.dropbox.com/doc/Sift-Java-Internal-README-smaYw88vZPgdkrAbuJdY6
* Increment minor version
* publish to maven
* github release.

