### PR TITLE
(NR) Use jar packaging instead of pom packaging

### DIFF
--- a/CHANGES.MD
+++ b/CHANGES.MD
@@ -2,6 +2,7 @@
 ==================
 
 - Make base model classes public.
+- Packaging with "jar" instead of "pom".
 
 1.3 (2017-01-17)
 ==================

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ signing {
 def pomConfig = {
     name "${project.name}"
     url 'https://github.com/SiftScience/sift-java'
+    packaging 'jar'
     licenses {
         license {
             name 'MIT License'
@@ -94,6 +95,8 @@ publishing {
             artifact(javaDocJar) {
                 classifier = "javadoc"
             }
+
+            pom.packaging = "jar"
 
             pom.withXml {
                 configurations.compile.resolvedConfiguration.firstLevelModuleDependencies.each {


### PR DESCRIPTION
@garylee1 For reasons unknown to me, both of those lines seem to be necessary. The effect that this has is it changes the packaging line in the generated pom from 
```
<packaging>pom</packaging>
```
to 
```
<packaging>jar</packaging>
```