### PR TITLE
Throw a ServerException for all 5xx server responses

### DIFF
--- a/src/main/java/com/siftscience/SiftResponse.java
+++ b/src/main/java/com/siftscience/SiftResponse.java
@@ -1,5 +1,7 @@
 package com.siftscience;
 
+import com.google.gson.JsonSyntaxException;
+import com.siftscience.exception.ServerException;
 import com.siftscience.model.BaseResponseBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
@@ -24,7 +26,16 @@ public abstract class SiftResponse<T extends BaseResponseBody<T>> {
         if (rspBody != null) {
             String bodyString = rspBody.string();
             if (!bodyString.isEmpty()) {
-                populateBodyFromJson(bodyString);
+                try {
+                    populateBodyFromJson(bodyString);
+                } catch (JsonSyntaxException e) {
+                    // If parsing the response body as JSON failed for a 5xx, ignore the parse
+                    // exception.
+                    int code = okResponse.code();
+                    if (code < 500 || code >= 600) {
+                        throw e;
+                    }
+                }
             }
         }
     }

--- a/src/test/java/com/siftscience/SiftClientTest.java
+++ b/src/test/java/com/siftscience/SiftClientTest.java
@@ -6,7 +6,9 @@ import okhttp3.HttpUrl;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.json.JSONException;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
@@ -21,6 +23,25 @@ import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
  * types according to the API docs.
  */
 public class SiftClientTest {
+
+    private final MockWebServer server = new MockWebServer();
+    private SiftClient client;
+
+    @Before
+    public void setup() throws IOException {
+        server.start();
+
+        HttpUrl baseUrl = server.url("");
+
+        // Create a new client and link it to the mock server.
+        client = new SiftClient("some_api_key");
+        client.setBaseUrl(baseUrl);
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        server.shutdown();
+    }
 
     /**
      * If the server sends a 51 Sift error code then we should throw an InvalidApiKeyException
@@ -37,8 +58,7 @@ public class SiftClientTest {
                 "  \"$user_email\"          : \"bill@gmail.com\",\n" +
                 "}";
 
-        // Start a new mock server and enqueue a mock response.
-        MockWebServer server = new MockWebServer();
+        // Enqueue a mock response.
         MockResponse response = new MockResponse();
         response.setResponseCode(HTTP_BAD_REQUEST);
         response.setBody("{\n" +
@@ -48,12 +68,6 @@ public class SiftClientTest {
                 "    \"request\" : \"" + TestUtils.unescapeJson(expectedRequestBody) + "\"\n" +
                 "}");
         server.enqueue(response);
-        server.start();
-        HttpUrl baseUrl = server.url("");
-
-        // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("invalid_api_key");
-        client.setBaseUrl(baseUrl);
 
         // Build a simplified request body.
         CreateOrderFieldSet fields = new CreateOrderFieldSet()
@@ -78,8 +92,6 @@ public class SiftClientTest {
         // Check that we can access the API key from the exception object.
         Assert.assertEquals("invalid_api_key",
                 apiKeyException.getSiftResponse().getRequestBody().getApiKey());
-
-        server.shutdown();
     }
 
     /**
@@ -96,8 +108,7 @@ public class SiftClientTest {
                 "  \"$order_id\"          : \"ORDER-28168441\"\n" +
                 "}";
 
-        // Start a new mock server and enqueue a mock response.
-        MockWebServer server = new MockWebServer();
+        // Enqueue a mock response.
         MockResponse response = new MockResponse();
         response.setResponseCode(HTTP_BAD_REQUEST);
         response.setBody("{\n" +
@@ -107,12 +118,6 @@ public class SiftClientTest {
                 "    \"request\" : \"" + TestUtils.unescapeJson(expectedRequestBody) + "\"\n" +
                 "}");
         server.enqueue(response);
-        server.start();
-        HttpUrl baseUrl = server.url("");
-
-        // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key");
-        client.setBaseUrl(baseUrl);
 
         // Build a simplified request body with the "missing field".
         CreateOrderFieldSet fields = new CreateOrderFieldSet()
@@ -132,8 +137,6 @@ public class SiftClientTest {
         Assert.assertNotNull(missingFieldException);
         Assert.assertEquals("Missing user email message from server.",
                 missingFieldException.getLocalizedMessage());
-
-        server.shutdown();
     }
 
     /**
@@ -144,8 +147,7 @@ public class SiftClientTest {
     public void testInvalidCustomFieldKeyException() throws IOException {
 
         // Create a new client and link it to a fake server address.
-        SiftClient client = new SiftClient("my_api_key");
-        client.setBaseUrl(HttpUrl.parse("http://fakehost:1234"));
+        client.setBaseUrl(HttpUrl.parse("http://fakehost.invalid:1234"));
 
         // Build a simple request. The exception should happen here instead of the request send
         // method.
@@ -179,8 +181,7 @@ public class SiftClientTest {
                 "  \"$user_email\"          : \"bill@gmail.com\",\n" +
                 "}";
 
-        // Start a new mock server and enqueue a mock response.
-        MockWebServer server = new MockWebServer();
+        // Enqueue a mock response.
         MockResponse response = new MockResponse();
         response.setResponseCode(HTTP_BAD_REQUEST);
         response.setBody("{\n" +
@@ -190,12 +191,6 @@ public class SiftClientTest {
                 "    \"request\" : \"" + TestUtils.unescapeJson(expectedRequestBody) + "\"\n" +
                 "}");
         server.enqueue(response);
-        server.start();
-        HttpUrl baseUrl = server.url("");
-
-        // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("some_api_key");
-        client.setBaseUrl(baseUrl);
 
         // Build a simplified request body.
         CreateOrderFieldSet fields = new CreateOrderFieldSet()
@@ -216,8 +211,6 @@ public class SiftClientTest {
         // We should have gotten an exception.
         Assert.assertNotNull(rateLimitException);
         Assert.assertEquals("Rate limit error message.", rateLimitException.getLocalizedMessage());
-
-        server.shutdown();
     }
 
     /**
@@ -226,27 +219,11 @@ public class SiftClientTest {
     @Test
     public void testGenericServerErrorException() throws IOException {
 
-        String expectedRequestBody = "{\n" +
-                "  \"$type\"             : \"$create_order\",\n" +
-                "  \"$api_key\"          : \"some_api_key\",\n" +
-                "  \"$user_id\"          : \"billy_jones_301\",\n" +
-                "  \"$order_id\"          : \"ORDER-28168441\",\n" +
-                "  \"$user_email\"          : \"bill@gmail.com\",\n" +
-                "}";
-
-        // Start a new mock server and enqueue a mock response. Note that it has no response body.
-        // We want to test that we get a reasonable ServerException in the case we get a 500 HTTP
-        // code and no response.
-        MockWebServer server = new MockWebServer();
+        // Enqueue a mock response. Note that it has no response body. We want to test that we
+        // get a reasonable ServerException in the case we get a 500 HTTP code and no response.
         MockResponse response = new MockResponse();
         response.setResponseCode(HTTP_INTERNAL_ERROR);
         server.enqueue(response);
-        server.start();
-        HttpUrl baseUrl = server.url("");
-
-        // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("some_api_key");
-        client.setBaseUrl(baseUrl);
 
         // Build a simplified request body.
         CreateOrderFieldSet fields = new CreateOrderFieldSet()
@@ -267,8 +244,40 @@ public class SiftClientTest {
         // We should have gotten an exception.
         Assert.assertNotNull(serverException);
         Assert.assertEquals("Unexpected API error.", serverException.getLocalizedMessage());
+    }
 
-        server.shutdown();
+    /**
+     * If the server responds with a 500 and a non-JSON response, throw a general server exception.
+     */
+    @Test
+    public void testGenericServerErrorExceptionNonJson() throws IOException {
+
+        // Enqueue a mock response. Note that it has no response body. We want to test that we
+        // get a reasonable ServerException in the case we get a 500 HTTP code and no response.
+        MockResponse response = new MockResponse();
+        response.setResponseCode(HTTP_INTERNAL_ERROR);
+        response.setBody("<html><body>Oops</body></html>");
+        server.enqueue(response);
+
+        // Build a simplified request body.
+        CreateOrderFieldSet fields = new CreateOrderFieldSet()
+                .setApiKey("some_api_key")
+                .setUserId("billy_jones_301")
+                .setOrderId("ORDER-28168441")
+                .setUserEmail("bill@gmail.com");
+
+        // Build and execute the request against the mock server.
+        SiftRequest request = client.buildRequest(fields);
+        ServerException serverException = null;
+        try {
+            request.send();
+        } catch (ServerException e) {
+            serverException = e;
+        }
+
+        // We should have gotten an exception.
+        Assert.assertNotNull(serverException);
+        Assert.assertEquals("Unexpected API error.", serverException.getLocalizedMessage());
     }
 
     /**


### PR DESCRIPTION
While investigating #18, we discovered the likely cause was failing to
parse the response body for 5xx responses as JSON. Instead of throwing
ServerException (like a 5xx with an empty body), a JsonSyntaxException
bubbles up to the caller. This changes that behavior so the exception
is consistent for 5xx responses.