### PR TITLE
(TNR) Set gradle version to match the CHANGES.MD version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'signing'
 apply plugin: 'java-library-distribution'
 
 group = 'com.siftscience'
-version = '1.5'
+version = '2.0'
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 


### PR DESCRIPTION
The gradle version wasn't changed to match the CHANGES.MD version. This PR updates it.