### PR TITLE
(for Gary) Move accountId to SiftClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Java 1.7 or later.
 <dependency>
     <groupId>com.siftscience</groupId>
     <artifactId>sift-java</artifactId>
-    <version>2.7.0</version>
+    <version>3.0.0</version>
 </dependency>
 ```
 ### Gradle
 ```
 dependencies {
-    compile 'com.siftscience:sift-java:2.7.0'
+    compile 'com.siftscience:sift-java:3.0.0'
 }
 ```
 ### Other
@@ -32,10 +32,10 @@ $ ./gradlew distZip   # Zip file saved to ./build/distributions/
 
 ## How To Use
 
-Create a SiftClient object with your API key. SiftClient is thread safe
+Create a SiftClient object with your API key and account id. SiftClient is thread-safe
 and can be used to access all supported APIs.
 ```java
-SiftClient client = new SiftClient("your_api_key");
+SiftClient client = new SiftClient("your_api_key", "your_account_id");
 ```
 
 ### Send Events
@@ -193,7 +193,6 @@ EventRequest createOrderRequest = client.buildRequest(createOrderFieldSet)
 To query the Workflow Status API, create a request with a WorkflowStatusFieldSet.
 ```java
 WorkflowStatusRequest request = client.buildRequest(new WorkflowStatusFieldSet()
-        .setAccountId("your_account_id")
         .setWorkflowRunId("someid"));
 ```
 
@@ -201,11 +200,10 @@ WorkflowStatusRequest request = client.buildRequest(new WorkflowStatusFieldSet()
 
 [API Docs](https://sift.com/developers/docs/java/decisions-api/apply-decision)
 
-To apply a decision to a user, create a request with accountId, userId, and ApplyDecisionFieldSet.
+To apply a decision to a user, create a request with userId and ApplyDecisionFieldSet.
 ```java
 ApplyDecisionRequest request = client.buildRequest(
         new ApplyDecisionFieldSet()
-            .setAccountId("your_account_id")
             .setUserId("a_user_id")
             .setDecisionId("decision_id")
             .setSource(DecisionSource.AUTOMATED_RULE)
@@ -213,11 +211,10 @@ ApplyDecisionRequest request = client.buildRequest(
 );
 ```
 
-To apply a decision to an order, create a request with accountId, userId, orderId and ApplyDecisionFieldSet.
+To apply a decision to an order, create a request with userId, orderId, and ApplyDecisionFieldSet.
 ```java
 ApplyDecisionRequest request = client.buildRequest(
         new ApplyDecisionFieldSet()
-            .setAccountId("your_account_id")
             .setUserId("a_user_id")
             .setOrderId("a_order_id")
             .setDecisionId("decision_id")
@@ -227,11 +224,10 @@ ApplyDecisionRequest request = client.buildRequest(
 );
 ```
 
-To apply a decision to a session, create a request with accountId, userId, sessionId and ApplyDecisionFieldSet.
+To apply a decision to a session, create a request with userId, sessionId, and ApplyDecisionFieldSet.
 ```java
 ApplyDecisionRequest request = client.buildRequest(
         new ApplyDecisionFieldSet()
-            .setAccountId("your_account_id")
             .setUserId("a_user_id")
             .setSessionId("a_session_id")
             .setDecisionId("decision_id")
@@ -241,11 +237,10 @@ ApplyDecisionRequest request = client.buildRequest(
 );
 ```
 
-To apply a decision to a piece of content, create a request with accountId, userId, contentId and ApplyDecisionFieldSet.
+To apply a decision to a piece of content, create a request with userId, contentId, and ApplyDecisionFieldSet.
 ```java
 ApplyDecisionRequest request = client.buildRequest(
         new ApplyDecisionFieldSet()
-            .setAccountId("your_account_id")
             .setUserId("a_user_id")
             .setContentId("a_content_id")
             .setDecisionId("decision_id")
@@ -263,14 +258,12 @@ ApplyDecisionRequest request = client.buildRequest(
 To retrieve available decisions, build a request with a GetDecisionsFieldSet.
 ```java
 GetDecisionsRequest request = client.buildRequest(new GetDecisionsFieldSet()
-        .setAbuseTypes(ImmutableList.of(AbuseType.PAYMENT_ABUSE, AbuseType.CONTENT_ABUSE))
-        .setAccountId("your_account_id"));
+        .setAbuseTypes(ImmutableList.of(AbuseType.PAYMENT_ABUSE, AbuseType.CONTENT_ABUSE)));
 ```
 
 Additionally, this field set supports filtering on results by entity and abuse type(s).
 ```java
-GetDecisionsRequest request = client.buildRequest(new GetDecisionsFieldSet()
-        .setAccountId("your_account_id"))
+GetDecisionsRequest request = client.buildRequest(new GetDecisionsFieldSet())
         .setEntityType(EntityType.ORDER)
         .setAbuseTypes(ImmutableList.of(AbuseType.PAYMENT_ABUSE, AbuseType.CONTENT_ABUSE))
 ```
@@ -279,8 +272,7 @@ Pagination is also supported, with offset by index (`from`) and limit (`limit`).
 The default `limit` is to return up to 100 results.
 The default offset value `from` is 0.
 ```java
-GetDecisionsRequest request = client.buildRequest(new GetDecisionsFieldSet()
-        .setAccountId("your_account_id"))
+GetDecisionsRequest request = client.buildRequest(new GetDecisionsFieldSet())
         .setFrom(15)
         .setLimit(10);  
 ```
@@ -302,7 +294,6 @@ GetDecisionsRequest nextRequest = client.buildRequest(GetDecisionsFieldSet.fromN
 To query the Decision Status API, create a request with a DecisionStatusFieldSet.
 ```java
 DecisionStatusRequest request = client.buildRequest(new DecisionStatusFieldSet()
-        .setAccountId("your_account_id")
         .setEntity(DecisionStatusFieldSet.ENTITY_ORDERS) // or ENTITY_USERS
         .setEntityId("someid"));
 ```
@@ -310,7 +301,6 @@ DecisionStatusRequest request = client.buildRequest(new DecisionStatusFieldSet()
 To query the Decision Status API for a Session, create a request with a DecisionStatusFieldSet, including a user id.
 ```java
 DecisionStatusRequest request = client.buildRequest(new DecisionStatusFieldSet()
-        .setAccountId("your_account_id")
         .setEntity(DecisionStatusFieldSet.ENTITY_SESSIONS)
         .setUserId("a_user_id")
         .setEntityId("a_session_id"));
@@ -319,7 +309,6 @@ DecisionStatusRequest request = client.buildRequest(new DecisionStatusFieldSet()
 To query the Decision Status API for Content, create a request with a DecisionStatusFieldSet, including a user id.
 ```java
 DecisionStatusRequest request = client.buildRequest(new DecisionStatusFieldSet()
-        .setAccountId("your_account_id")
         .setEntity(DecisionStatusFieldSet.ENTITY_CONTENT)
         .setUserId("a_user_id")
         .setEntityId("a_content_id"));

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ ./gradlew distZip   # Zip file saved to ./build/distributions/
 Create a SiftClient object with your API key and account id. SiftClient is thread-safe
 and can be used to access all supported APIs.
 ```java
-SiftClient client = new SiftClient("your_api_key", "your_account_id");
+SiftClient client = new SiftClient("YOUR_API_KEY", "YOUR_ACCOUNT_ID");
 ```
 
 ### Send Events

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'signing'
 apply plugin: 'java-library-distribution'
 
 group = 'com.siftscience'
-version = '2.7.0'
+version = '3.0.0'
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 

--- a/src/main/java/com/siftscience/ApplyDecisionRequest.java
+++ b/src/main/java/com/siftscience/ApplyDecisionRequest.java
@@ -7,14 +7,14 @@ import okhttp3.*;
 
 public class ApplyDecisionRequest extends SiftRequest<ApplyDecisionResponse>{
 
-    ApplyDecisionRequest(HttpUrl baseUrl, OkHttpClient okClient, ApplyDecisionFieldSet fields) {
-        super(baseUrl, okClient, fields);
+    ApplyDecisionRequest(HttpUrl baseUrl, String accountId, OkHttpClient okClient, ApplyDecisionFieldSet fields) {
+        super(baseUrl, accountId, okClient, fields);
     }
 
     @Override
     protected HttpUrl path(HttpUrl baseUrl) {
         HttpUrl.Builder path = baseUrl.newBuilder("v3/accounts")
-                .addPathSegment(((ApplyDecisionFieldSet) fieldSet).getAccountId())
+                .addPathSegment(getAccountId())
                 .addPathSegment("users")
                 .addPathSegment(((ApplyDecisionFieldSet) fieldSet).getUserId());
 

--- a/src/main/java/com/siftscience/DecisionStatusRequest.java
+++ b/src/main/java/com/siftscience/DecisionStatusRequest.java
@@ -9,8 +9,8 @@ import static com.siftscience.model.DecisionStatusFieldSet.ENTITY_CONTENT;
 import static com.siftscience.model.DecisionStatusFieldSet.ENTITY_SESSIONS;
 
 public class DecisionStatusRequest extends SiftRequest<DecisionStatusResponse> {
-    DecisionStatusRequest(HttpUrl baseUrl, OkHttpClient okClient, DecisionStatusFieldSet fields) {
-        super(baseUrl, okClient, fields);
+    DecisionStatusRequest(HttpUrl baseUrl, String accountId, OkHttpClient okClient, DecisionStatusFieldSet fields) {
+        super(baseUrl, accountId, okClient, fields);
     }
 
     @Override
@@ -18,7 +18,7 @@ public class DecisionStatusRequest extends SiftRequest<DecisionStatusResponse> {
         HttpUrl.Builder builder = baseUrl.newBuilder()
             .addPathSegment("v3")
             .addPathSegment("accounts")
-            .addPathSegment(((DecisionStatusFieldSet)fieldSet).getAccountId());
+            .addPathSegment(getAccountId());
         String entity = ((DecisionStatusFieldSet)fieldSet).getEntity();
         if (entity.equals(ENTITY_CONTENT) || entity.equals(ENTITY_SESSIONS)) {
             builder = builder

--- a/src/main/java/com/siftscience/EventRequest.java
+++ b/src/main/java/com/siftscience/EventRequest.java
@@ -18,8 +18,8 @@ public class EventRequest extends SiftRequest<EventResponse> {
     private boolean isWorkflowStatus = false;
     private boolean forceWorkflowRun = false;
 
-    EventRequest(HttpUrl baseUrl, OkHttpClient okClient, FieldSet fields) {
-        super(baseUrl, okClient, fields);
+    EventRequest(HttpUrl baseUrl, String accountId, OkHttpClient okClient, FieldSet fields) {
+        super(baseUrl, accountId, okClient, fields);
         abuseTypes = null;
     }
 
@@ -46,12 +46,7 @@ public class EventRequest extends SiftRequest<EventResponse> {
 
         // returnScore and abuseTypes are encoded into the URL as query params rather than JSON.
         if (abuseTypes != null && abuseTypes.size() > 0) {
-            String queryParamVal = "";
-            for (String abuseType : abuseTypes) {
-                queryParamVal += (abuseType + ",");
-            }
-            builder.addQueryParameter("abuse_types",
-                    queryParamVal.substring(0, queryParamVal.length() - 1));
+            builder.addQueryParameter("abuse_types", StringUtils.joinWithComma(abuseTypes));
         }
         return builder.build();
     }

--- a/src/main/java/com/siftscience/GetDecisionsRequest.java
+++ b/src/main/java/com/siftscience/GetDecisionsRequest.java
@@ -12,8 +12,8 @@ import okhttp3.Response;
 
 public class GetDecisionsRequest extends SiftRequest<GetDecisionsResponse> {
 
-    GetDecisionsRequest(HttpUrl baseUrl, OkHttpClient okClient, FieldSet fields) {
-        super(baseUrl, okClient, fields);
+    GetDecisionsRequest(HttpUrl baseUrl, String accountId, OkHttpClient okClient, FieldSet fields) {
+        super(baseUrl, accountId, okClient, fields);
     }
 
     public enum Query {
@@ -38,7 +38,7 @@ public class GetDecisionsRequest extends SiftRequest<GetDecisionsResponse> {
     protected HttpUrl path(HttpUrl baseUrl) {
         GetDecisionFieldSet fieldSet = (GetDecisionFieldSet) this.fieldSet;
         HttpUrl.Builder path = baseUrl.newBuilder("/v3/accounts")
-                .addPathSegment(fieldSet.getAccountId())
+                .addPathSegment(getAccountId())
                 .addPathSegment("decisions");
 
         if (fieldSet.getEntityType() != null) {

--- a/src/main/java/com/siftscience/LabelRequest.java
+++ b/src/main/java/com/siftscience/LabelRequest.java
@@ -12,8 +12,8 @@ import java.io.IOException;
  * https://siftscience.com/developers/docs/curl/labels-api
  */
 public class LabelRequest extends SiftRequest<LabelResponse> {
-    LabelRequest(HttpUrl baseUrl, OkHttpClient okClient, LabelFieldSet fields) {
-        super(baseUrl, okClient, fields);
+    LabelRequest(HttpUrl baseUrl, String accountId, OkHttpClient okClient, LabelFieldSet fields) {
+        super(baseUrl, accountId, okClient, fields);
     }
 
     @Override

--- a/src/main/java/com/siftscience/ScoreRequest.java
+++ b/src/main/java/com/siftscience/ScoreRequest.java
@@ -13,8 +13,8 @@ import java.io.IOException;
  * https://siftscience.com/developers/docs/curl/score-api
  */
 public class ScoreRequest extends SiftRequest<ScoreResponse> {
-    ScoreRequest(HttpUrl baseUrl, OkHttpClient okClient, ScoreFieldSet fields) {
-        super(baseUrl, okClient, fields);
+    ScoreRequest(HttpUrl baseUrl, String accountId, OkHttpClient okClient, ScoreFieldSet fields) {
+        super(baseUrl, accountId, okClient, fields);
     }
 
     /**
@@ -42,12 +42,8 @@ public class ScoreRequest extends SiftRequest<ScoreResponse> {
         builder.addPathSegment("score").addPathSegment(scoreFieldSet.getUserId())
                 .addQueryParameter("api_key", scoreFieldSet.getApiKey());
         if (scoreFieldSet.getAbuseTypes() != null && scoreFieldSet.getAbuseTypes().size() > 0) {
-            String queryParamVal = "";
-            for (String abuseType : scoreFieldSet.getAbuseTypes()) {
-                queryParamVal += (abuseType + ",");
-            }
             builder.addQueryParameter("abuse_types",
-                    queryParamVal.substring(0, queryParamVal.length() - 1));
+                StringUtils.joinWithComma(scoreFieldSet.getAbuseTypes()));
         }
         return builder.build();
     }

--- a/src/main/java/com/siftscience/SiftClient.java
+++ b/src/main/java/com/siftscience/SiftClient.java
@@ -1,10 +1,15 @@
 package com.siftscience;
 
-import com.siftscience.model.*;
+import com.siftscience.model.ApplyDecisionFieldSet;
+import com.siftscience.model.DecisionStatusFieldSet;
+import com.siftscience.model.GetDecisionFieldSet;
+import com.siftscience.model.LabelFieldSet;
+import com.siftscience.model.ScoreFieldSet;
+import com.siftscience.model.UnlabelFieldSet;
+import com.siftscience.model.UserScoreFieldSet;
+import com.siftscience.model.WorkflowStatusFieldSet;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
-
-import java.util.List;
 
 /**
  * Use a SiftClient to access all supported Sift Science APIs. It may be used concurrently from
@@ -34,77 +39,78 @@ import java.util.List;
  *
  */
 public class SiftClient {
-    private String apiKey;
+    private final String accountId;
+    private final String apiKey;
     private OkHttpClient okClient = new OkHttpClient();
-    private HttpUrl baseUrl = HttpUrl.parse("https://api.siftscience.com");
-    private HttpUrl baseApi3Url = HttpUrl.parse("https://api3.siftscience.com");
+    private HttpUrl baseUrl = HttpUrl.parse("https://api.sift.com");
 
-    public SiftClient(String apiKey) {
+    public SiftClient(String apiKey, String accountId) {
         this.apiKey = apiKey;
+        this.accountId = accountId;
     }
 
     public String getApiKey() {
         return apiKey;
     }
 
+    public String getAccountId() {
+        return accountId;
+    }
+
     public EventRequest buildRequest(FieldSet fields) {
         setupApiKey(fields);
-        return new EventRequest(baseUrl, okClient, fields);
+        return new EventRequest(baseUrl, getAccountId(), okClient, fields);
     }
 
     public ApplyDecisionRequest buildRequest(ApplyDecisionFieldSet fields) {
         setupApiKey(fields);
-        return new ApplyDecisionRequest(baseApi3Url, okClient, fields);
+        return new ApplyDecisionRequest(baseUrl, getAccountId(), okClient, fields);
     }
 
     public GetDecisionsRequest buildRequest(GetDecisionFieldSet fields) {
         setupApiKey(fields);
-        return new GetDecisionsRequest(baseApi3Url, okClient, fields);
+        return new GetDecisionsRequest(baseUrl, getAccountId(), okClient, fields);
     }
 
     public DecisionStatusRequest buildRequest(DecisionStatusFieldSet fields) {
         setupApiKey(fields);
-        return new DecisionStatusRequest(baseApi3Url, okClient, fields);
+        return new DecisionStatusRequest(baseUrl, getAccountId(), okClient, fields);
     }
 
     public LabelRequest buildRequest(LabelFieldSet fields) {
         setupApiKey(fields);
-        return new LabelRequest(baseUrl, okClient, fields);
+        return new LabelRequest(baseUrl, getAccountId(), okClient, fields);
     }
 
     public UnlabelRequest buildRequest(UnlabelFieldSet fields) {
         setupApiKey(fields);
-        return new UnlabelRequest(baseUrl, okClient, fields);
+        return new UnlabelRequest(baseUrl, getAccountId(), okClient, fields);
     }
 
     public ScoreRequest buildRequest(ScoreFieldSet fields) {
         setupApiKey(fields);
-        return new ScoreRequest(baseUrl, okClient, fields);
+        return new ScoreRequest(baseUrl, getAccountId(), okClient, fields);
     }
 
     public UserScoreRequest buildRequest(UserScoreFieldSet fields) {
         setupApiKey(fields);
-        return new UserScoreRequest(baseUrl, okClient, fields);
+        return new UserScoreRequest(baseUrl, getAccountId(), okClient, fields);
     }
 
     public WorkflowStatusRequest buildRequest(WorkflowStatusFieldSet fields) {
         setupApiKey(fields);
-        return new WorkflowStatusRequest(baseApi3Url, okClient, fields);
+        return new WorkflowStatusRequest(baseUrl, getAccountId(), okClient, fields);
     }
 
     private void setupApiKey(FieldSet fields) {
         if (fields.getApiKey() == null) {
-            fields.setApiKey(apiKey);
+            fields.setApiKey(getApiKey());
         }
     }
 
     // For testing.
     SiftClient setBaseUrl(HttpUrl baseUrl) {
         this.baseUrl = baseUrl;
-        return this;
-    }
-    SiftClient setBaseApi3Url(HttpUrl baseApi3Url) {
-        this.baseApi3Url = baseApi3Url;
         return this;
     }
 }

--- a/src/main/java/com/siftscience/SiftClient.java
+++ b/src/main/java/com/siftscience/SiftClient.java
@@ -17,7 +17,7 @@ import okhttp3.OkHttpClient;
  *
  * Usage:
  *
- * SiftClient client = new SiftClient("your_api_key");
+ * SiftClient client = new SiftClient("YOUR_API_KEY");
  * EventRequest txEventRequest = client.buildRequest(
  *      new TransactionFieldSet()
  *              .setUserId("some_user_id")

--- a/src/main/java/com/siftscience/SiftRequest.java
+++ b/src/main/java/com/siftscience/SiftRequest.java
@@ -10,6 +10,7 @@ import java.io.IOException;
  * should be used by all subtypes as it provides standard error handling logic.
  */
 public abstract class SiftRequest<T extends SiftResponse> {
+    private final String accountId;
     FieldSet fieldSet;
     private OkHttpClient okClient;
     private HttpUrl baseUrl;
@@ -20,8 +21,9 @@ public abstract class SiftRequest<T extends SiftResponse> {
         return path(baseUrl);
     }
 
-    SiftRequest(HttpUrl baseUrl, OkHttpClient okClient, FieldSet fields) {
+    SiftRequest(HttpUrl baseUrl, String accountId, OkHttpClient okClient, FieldSet fields) {
         this.baseUrl = baseUrl;
+        this.accountId = accountId;
         this.okClient = okClient;
         this.fieldSet = fields;
     }
@@ -80,5 +82,9 @@ public abstract class SiftRequest<T extends SiftResponse> {
 
     public FieldSet getFieldSet() {
         return fieldSet;
+    }
+
+    protected String getAccountId() {
+        return accountId;
     }
 }

--- a/src/main/java/com/siftscience/UnlabelRequest.java
+++ b/src/main/java/com/siftscience/UnlabelRequest.java
@@ -10,8 +10,9 @@ import java.io.IOException;
  * https://siftscience.com/developers/docs/curl/labels-api/unlabel-user
  */
 public class UnlabelRequest extends SiftRequest<UnlabelResponse> {
-    UnlabelRequest(HttpUrl baseUrl, OkHttpClient okClient, UnlabelFieldSet fields) {
-        super(baseUrl, okClient, fields);
+    UnlabelRequest(HttpUrl baseUrl, String accountId, OkHttpClient okClient,
+                   UnlabelFieldSet fields) {
+        super(baseUrl, accountId, okClient, fields);
     }
 
     /**

--- a/src/main/java/com/siftscience/UserScoreRequest.java
+++ b/src/main/java/com/siftscience/UserScoreRequest.java
@@ -19,8 +19,9 @@ import java.io.IOException;
  *    See details here: https://siftscience.com/developers/docs/java/score-api/rescore
  */
 public class UserScoreRequest extends SiftRequest<EntityScoreResponse> {
-    UserScoreRequest(HttpUrl baseUrl, OkHttpClient okClient, UserScoreFieldSet fields) {
-        super(baseUrl, okClient, fields);
+    UserScoreRequest(HttpUrl baseUrl, String accountId, OkHttpClient okClient,
+                     UserScoreFieldSet fields) {
+        super(baseUrl, accountId, okClient, fields);
     }
 
     /**

--- a/src/main/java/com/siftscience/WorkflowStatusRequest.java
+++ b/src/main/java/com/siftscience/WorkflowStatusRequest.java
@@ -7,21 +7,20 @@ import okhttp3.*;
 import java.io.IOException;
 
 public class WorkflowStatusRequest extends SiftRequest<WorkflowStatusResponse> {
-    WorkflowStatusRequest(HttpUrl baseUrl, OkHttpClient okClient, FieldSet fields) {
-        super(baseUrl, okClient, fields);
+    WorkflowStatusRequest(HttpUrl baseUrl, String accountId, OkHttpClient okClient, FieldSet fields) {
+        super(baseUrl, accountId, okClient, fields);
     }
 
     @Override
     protected HttpUrl path(HttpUrl baseUrl) {
-        HttpUrl url = baseUrl.newBuilder()
+        return baseUrl.newBuilder()
                 .addPathSegment("v3")
                 .addPathSegment("accounts")
-                .addPathSegment(((WorkflowStatusFieldSet)fieldSet).getAccountId())
+                .addPathSegment(getAccountId())
                 .addPathSegment("workflows")
                 .addPathSegment("runs")
                 .addPathSegment(((WorkflowStatusFieldSet)fieldSet).getWorkflowRunId())
                 .build();
-        return url;
     }
 
     @Override

--- a/src/main/java/com/siftscience/model/ApplyDecisionFieldSet.java
+++ b/src/main/java/com/siftscience/model/ApplyDecisionFieldSet.java
@@ -50,7 +50,6 @@ public class ApplyDecisionFieldSet extends FieldSet<ApplyDecisionFieldSet> {
     @Expose @SerializedName("analyst") private String analyst;
     @Expose @SerializedName("description") private String description;
     @Expose @SerializedName("time") private Long time;
-    private String accountId;
     private String userId;
     private String orderId;
     private String sessionId;
@@ -80,15 +79,6 @@ public class ApplyDecisionFieldSet extends FieldSet<ApplyDecisionFieldSet> {
 
     public ApplyDecisionFieldSet setTime(Long time) {
         this.time = time;
-        return this;
-    }
-
-    public String getAccountId() {
-        return accountId;
-    }
-
-    public ApplyDecisionFieldSet setAccountId(String accountId) {
-        this.accountId = accountId;
         return this;
     }
 

--- a/src/main/java/com/siftscience/model/DecisionStatusFieldSet.java
+++ b/src/main/java/com/siftscience/model/DecisionStatusFieldSet.java
@@ -9,19 +9,9 @@ public class DecisionStatusFieldSet extends FieldSet<DecisionStatusFieldSet> {
     public static final String ENTITY_SESSIONS = "sessions";
     public static final String ENTITY_CONTENT = "content";
 
-    private String accountId;
     private String entity;
     private String entityId;
     private String userId;
-
-    public String getAccountId() {
-        return accountId;
-    }
-
-    public DecisionStatusFieldSet setAccountId(String accountId) {
-        this.accountId = accountId;
-        return this;
-    }
 
     public String getEntity() {
         return entity;

--- a/src/main/java/com/siftscience/model/GetDecisionFieldSet.java
+++ b/src/main/java/com/siftscience/model/GetDecisionFieldSet.java
@@ -14,13 +14,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class GetDecisionFieldSet extends FieldSet<GetDecisionFieldSet> {
-    private String accountId;
     private Integer limit;
     private Integer from;
     private EntityType entityType;
     private List<AbuseType> abuseTypes;
-    private static final Pattern ACCOUNT_ID_PATTERN = Pattern
-            .compile("(?<=accounts/)\\p{XDigit}+[^/]");
 
     public GetDecisionFieldSet() {}
 
@@ -32,17 +29,10 @@ public class GetDecisionFieldSet extends FieldSet<GetDecisionFieldSet> {
         Objects.requireNonNull(nextRef,"Must provide valid nextRef");
         URI uri = URI.create(nextRef);
         String queries = uri.getQuery();
-            if ( queries == null || queries.isEmpty()) {
+            if (queries == null || queries.isEmpty()) {
             throw new InvalidRequestException("Invalid format for nextRef " + nextRef);
         } else {
             GetDecisionFieldSet fieldSet = new GetDecisionFieldSet();
-                Matcher matcher = ACCOUNT_ID_PATTERN.matcher(uri.getPath());
-                if (matcher.find()) {
-                    fieldSet.setAccountId(matcher.group());
-                } else {
-                    throw new InvalidFieldException("Unable to parse accountId from ref " +
-                            nextRef);
-                }
             for (String query : queries.split("&")) {
                 String[] pair = query.split("=");
                 if (pair.length == 2) {
@@ -84,11 +74,6 @@ public class GetDecisionFieldSet extends FieldSet<GetDecisionFieldSet> {
     public enum EntityType {USER, ORDER, SESSION, CONTENT}
     public enum DecisionCategory {BLOCK, WATCH, ACCEPT}
 
-    public GetDecisionFieldSet setAccountId(String accountId) {
-        this.accountId = accountId;
-        return this;
-    }
-
     public GetDecisionFieldSet setLimit(Integer limit) {
         this.limit = limit;
         return this;
@@ -107,10 +92,6 @@ public class GetDecisionFieldSet extends FieldSet<GetDecisionFieldSet> {
     public GetDecisionFieldSet setAbuseTypes(List<AbuseType> abuseTypes) {
         this.abuseTypes = abuseTypes;
         return this;
-    }
-
-    public String getAccountId() {
-        return accountId;
     }
 
     public Integer getLimit() {

--- a/src/main/java/com/siftscience/model/WorkflowStatusFieldSet.java
+++ b/src/main/java/com/siftscience/model/WorkflowStatusFieldSet.java
@@ -3,17 +3,7 @@ package com.siftscience.model;
 import com.siftscience.FieldSet;
 
 public class WorkflowStatusFieldSet extends FieldSet<WorkflowStatusFieldSet> {
-    private String accountId;
     private String workflowRunId;
-
-    public String getAccountId() {
-        return accountId;
-    }
-
-    public WorkflowStatusFieldSet setAccountId(String accountId) {
-        this.accountId = accountId;
-        return this;
-    }
 
     public String getWorkflowRunId() {
         return workflowRunId;

--- a/src/test/java/com/siftscience/AddItemToCartEventTest.java
+++ b/src/test/java/com/siftscience/AddItemToCartEventTest.java
@@ -51,7 +51,7 @@ public class AddItemToCartEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.

--- a/src/test/java/com/siftscience/AddItemToCartEventTest.java
+++ b/src/test/java/com/siftscience/AddItemToCartEventTest.java
@@ -17,7 +17,7 @@ public class AddItemToCartEventTest {
     public void testAddItemToCart() throws Exception {
         String expectedRequestBody = "{\n" +
             "  \"$type\"       : \"$add_item_to_cart\",\n" +
-            "  \"$api_key\"    : \"your_api_key_here\",\n" +
+            "  \"$api_key\"    : \"\",\n" +
             "  \"$user_id\"    : \"billy_jones_301\",\n" +
             "\n" +
             "  \"$session_id\" : \"gigtleqddo84l8cm15qe4il\",\n" +
@@ -51,7 +51,7 @@ public class AddItemToCartEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.

--- a/src/test/java/com/siftscience/AddPromotionEventTest.java
+++ b/src/test/java/com/siftscience/AddPromotionEventTest.java
@@ -20,7 +20,7 @@ public class AddPromotionEventTest {
     public void testAddPromotion() throws Exception {
         String expectedRequestBody = "{\n" +
                 "  \"$type\"       : \"$add_promotion\",\n" +
-                "  \"$api_key\"    : \"your_api_key\",\n" +
+                "  \"$api_key\"    : \"YOUR_API_KEY\",\n" +
                 "  \"$user_id\"    : \"billy_jones_301\",\n" +
                 "\n" +
                 "  \"$promotions\" : [\n" +
@@ -52,7 +52,7 @@ public class AddPromotionEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key", "your_account_id");
+        SiftClient client = new SiftClient("YOUR_API_KEY", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         // Sample promotions.

--- a/src/test/java/com/siftscience/AddPromotionEventTest.java
+++ b/src/test/java/com/siftscience/AddPromotionEventTest.java
@@ -52,7 +52,7 @@ public class AddPromotionEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key");
+        SiftClient client = new SiftClient("your_api_key", "your_account_id");
         client.setBaseUrl(baseUrl);
 
         // Sample promotions.

--- a/src/test/java/com/siftscience/ApplyDecisionTest.java
+++ b/src/test/java/com/siftscience/ApplyDecisionTest.java
@@ -44,13 +44,13 @@ public class ApplyDecisionTest {
         server.enqueue(response);
         server.start();
 
-        String accountId = "your_account_id";
+        String accountId = "YOUR_ACCOUNT_ID";
         String userId = "a_user_id";
 
         HttpUrl baseUrl = server.url("").newBuilder().build();
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key", accountId);
+        SiftClient client = new SiftClient("YOUR_API_KEY", accountId);
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.
@@ -106,14 +106,14 @@ public class ApplyDecisionTest {
         server.enqueue(response);
         server.start();
 
-        String accountId = "your_account_id";
+        String accountId = "YOUR_ACCOUNT_ID";
         String userId = "a_user_id";
         String orderId = "an_order_id";
 
         HttpUrl baseUrl = server.url("").newBuilder().build();
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key", accountId);
+        SiftClient client = new SiftClient("YOUR_API_KEY", accountId);
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.
@@ -177,14 +177,14 @@ public class ApplyDecisionTest {
         server.enqueue(response);
         server.start();
 
-        String accountId = "your_account_id";
+        String accountId = "YOUR_ACCOUNT_ID";
         String userId = "a_user_id";
         String contentId = "a_content_id";
 
         HttpUrl baseUrl = server.url("").newBuilder().build();
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key", accountId);
+        SiftClient client = new SiftClient("YOUR_API_KEY", accountId);
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.

--- a/src/test/java/com/siftscience/ApplyDecisionTest.java
+++ b/src/test/java/com/siftscience/ApplyDecisionTest.java
@@ -47,16 +47,15 @@ public class ApplyDecisionTest {
         String accountId = "your_account_id";
         String userId = "a_user_id";
 
-        HttpUrl baseApi3Url = server.url("").newBuilder().build();
+        HttpUrl baseUrl = server.url("").newBuilder().build();
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key");
-        client.setBaseApi3Url(baseApi3Url);
+        SiftClient client = new SiftClient("your_api_key", accountId);
+        client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.
         ApplyDecisionRequest request = client.buildRequest(
                 new ApplyDecisionFieldSet()
-                        .setAccountId(accountId)
                         .setUserId(userId)
                         .setDecisionId("looks_ok_account_abuse")
                         .setSource(DecisionSource.MANUAL_REVIEW)
@@ -111,16 +110,15 @@ public class ApplyDecisionTest {
         String userId = "a_user_id";
         String orderId = "an_order_id";
 
-        HttpUrl baseApi3Url = server.url("").newBuilder().build();
+        HttpUrl baseUrl = server.url("").newBuilder().build();
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key");
-        client.setBaseApi3Url(baseApi3Url);
+        SiftClient client = new SiftClient("your_api_key", accountId);
+        client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.
         ApplyDecisionRequest request = client.buildRequest(
                 new ApplyDecisionFieldSet()
-                        .setAccountId(accountId)
                         .setUserId(userId)
                         .setOrderId(orderId)
                         .setDecisionId("order_looks_bad_payment_abuse")
@@ -183,16 +181,15 @@ public class ApplyDecisionTest {
         String userId = "a_user_id";
         String contentId = "a_content_id";
 
-        HttpUrl baseApi3Url = server.url("").newBuilder().build();
+        HttpUrl baseUrl = server.url("").newBuilder().build();
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key");
-        client.setBaseApi3Url(baseApi3Url);
+        SiftClient client = new SiftClient("your_api_key", accountId);
+        client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.
         ApplyDecisionRequest request = client.buildRequest(
             new ApplyDecisionFieldSet()
-                .setAccountId(accountId)
                 .setUserId(userId)
                 .setContentId(contentId)
                 .setDecisionId("content_looks_bad_content_abuse")

--- a/src/test/java/com/siftscience/BaseAppBrowserFieldSetTest.java
+++ b/src/test/java/com/siftscience/BaseAppBrowserFieldSetTest.java
@@ -48,6 +48,7 @@ import static org.hamcrest.object.IsCompatibleType.typeCompatibleWith;
 public class BaseAppBrowserFieldSetTest {
 
     private static final String DUMMY_API_KEY = "your_api_key_here";
+    private static final String DUMMY_ACCOUNT_ID = "your_account_id_here";
     private static final String DUMMY_TEST_FIELD = "test";
     private static final String DUMMY_USERID = "billy_jones_301";
     private static final String REQUEST_BODY_TEMPLATE = "{\n" +
@@ -151,7 +152,7 @@ public class BaseAppBrowserFieldSetTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient(DUMMY_API_KEY);
+        SiftClient client = new SiftClient(DUMMY_API_KEY, DUMMY_ACCOUNT_ID);
         client.setBaseUrl(baseUrl);
 
         SiftRequest request = client.buildRequest(t);

--- a/src/test/java/com/siftscience/BaseAppBrowserFieldSetTest.java
+++ b/src/test/java/com/siftscience/BaseAppBrowserFieldSetTest.java
@@ -47,8 +47,8 @@ import static org.hamcrest.object.IsCompatibleType.typeCompatibleWith;
 
 public class BaseAppBrowserFieldSetTest {
 
-    private static final String DUMMY_API_KEY = "your_api_key_here";
-    private static final String DUMMY_ACCOUNT_ID = "your_account_id_here";
+    private static final String DUMMY_API_KEY = "";
+    private static final String DUMMY_ACCOUNT_ID = "YOUR_ACCOUNT_ID";
     private static final String DUMMY_TEST_FIELD = "test";
     private static final String DUMMY_USERID = "billy_jones_301";
     private static final String REQUEST_BODY_TEMPLATE = "{\n" +

--- a/src/test/java/com/siftscience/ChargebackEventTest.java
+++ b/src/test/java/com/siftscience/ChargebackEventTest.java
@@ -16,7 +16,7 @@ public class ChargebackEventTest {
     public void testChargeback() throws Exception {
         String expectedRequestBody = "{\n" +
                 "  \"$type\"              : \"$chargeback\",\n" +
-                "  \"$api_key\"           : \"your_api_key_here\",\n" +
+                "  \"$api_key\"           : \"\",\n" +
                 "  \"$user_id\"           : \"billy_jones_301\",\n" +
                 "  \"$order_id\"          : \"ORDER-123124124\",\n" +
                 "  \"$transaction_id\"    : \"719637215\",\n" +
@@ -40,7 +40,7 @@ public class ChargebackEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.

--- a/src/test/java/com/siftscience/ChargebackEventTest.java
+++ b/src/test/java/com/siftscience/ChargebackEventTest.java
@@ -40,7 +40,7 @@ public class ChargebackEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.

--- a/src/test/java/com/siftscience/ContentDecisionStatusTest.java
+++ b/src/test/java/com/siftscience/ContentDecisionStatusTest.java
@@ -39,13 +39,12 @@ public class ContentDecisionStatusTest {
         baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key");
-        client.setBaseApi3Url(baseUrl);
+        SiftClient client = new SiftClient("your_api_key", "your_account_id");
+        client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.
         DecisionStatusRequest request = client.buildRequest(
             new DecisionStatusFieldSet()
-                .setAccountId("your_account_id")
                 .setUserId("someuser")
                 .setEntity(DecisionStatusFieldSet.ENTITY_CONTENT)
                 .setEntityId("someid"));

--- a/src/test/java/com/siftscience/ContentDecisionStatusTest.java
+++ b/src/test/java/com/siftscience/ContentDecisionStatusTest.java
@@ -39,7 +39,7 @@ public class ContentDecisionStatusTest {
         baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key", "your_account_id");
+        SiftClient client = new SiftClient("YOUR_API_KEY", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.
@@ -53,7 +53,7 @@ public class ContentDecisionStatusTest {
         // Verify the request.
         RecordedRequest request1 = server.takeRequest();
         Assert.assertEquals("GET", request1.getMethod());
-        Assert.assertEquals("/v3/accounts/your_account_id/users/someuser/content/someid/decisions",
+        Assert.assertEquals("/v3/accounts/YOUR_ACCOUNT_ID/users/someuser/content/someid/decisions",
             request1.getPath());
         Assert.assertEquals(request1.getHeader("Authorization"), "Basic eW91cl9hcGlfa2V5Og==");
 

--- a/src/test/java/com/siftscience/ContentEventTest.java
+++ b/src/test/java/com/siftscience/ContentEventTest.java
@@ -77,7 +77,7 @@ public class ContentEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("YOUR_API_KEY_HERE");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         Image image = new Image()
@@ -182,7 +182,7 @@ public class ContentEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("YOUR_API_KEY_HERE");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         Image image = new Image()
@@ -287,7 +287,7 @@ public class ContentEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("YOUR_API_KEY_HERE");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         Image image = new Image()
@@ -377,7 +377,7 @@ public class ContentEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("YOUR_API_KEY_HERE");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         Image image = new Image()
@@ -483,7 +483,7 @@ public class ContentEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("YOUR_API_KEY_HERE");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         Image image = new Image()
@@ -593,7 +593,7 @@ public class ContentEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("YOUR_API_KEY_HERE");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         Image image = new Image()
@@ -686,7 +686,7 @@ public class ContentEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("YOUR_API_KEY_HERE");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         Image image = new Image()
@@ -791,7 +791,7 @@ public class ContentEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("YOUR_API_KEY_HERE");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         Image image = new Image()
@@ -898,7 +898,7 @@ public class ContentEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("YOUR_API_KEY_HERE");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         Image image = new Image()
@@ -990,7 +990,7 @@ public class ContentEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("YOUR_API_KEY_HERE");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         Image image = new Image()
@@ -1096,7 +1096,7 @@ public class ContentEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("YOUR_API_KEY_HERE");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         Image image = new Image()
@@ -1206,7 +1206,7 @@ public class ContentEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("YOUR_API_KEY_HERE");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         Image image = new Image()

--- a/src/test/java/com/siftscience/ContentEventTest.java
+++ b/src/test/java/com/siftscience/ContentEventTest.java
@@ -42,7 +42,7 @@ public class ContentEventTest {
     public void testCreateComment() throws Exception {
         String expectedRequestBody = "{\n" +
             "  \"$type\"       : \"$create_content\",\n" +
-            "  \"$api_key\"    : \"YOUR_API_KEY_HERE\",\n" +
+            "  \"$api_key\"    : \"_HERE\",\n" +
             "  \"$user_id\"    : \"fyw3989sjpqr71\",\n" +
             "  \"$content_id\"       : \"comment-23412\",\n" +
             "\n" +
@@ -77,7 +77,7 @@ public class ContentEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         Image image = new Image()
@@ -97,7 +97,7 @@ public class ContentEventTest {
 
         // Build and execute the request against the mock server.
         SiftRequest request = client.buildRequest(new CreateCommentFieldSet()
-            .setApiKey("YOUR_API_KEY_HERE")
+            .setApiKey("_HERE")
             .setUserId("fyw3989sjpqr71")
             .setContentId("comment-23412")
             .setSessionId("a234ksjfgn435sfg")
@@ -127,7 +127,7 @@ public class ContentEventTest {
     public void testCreateListing() throws Exception {
         String expectedRequestBody = "{\n" +
             "  \"$type\"       : \"$create_content\",\n" +
-            "  \"$api_key\"    : \"YOUR_API_KEY_HERE\",\n" +
+            "  \"$api_key\"    : \"_HERE\",\n" +
             "  \"$user_id\"    : \"fyw3989sjpqr71\",\n" +
             "  \"$content_id\"       : \"comment-23412\",\n" +
             "\n" +
@@ -182,7 +182,7 @@ public class ContentEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         Image image = new Image()
@@ -224,7 +224,7 @@ public class ContentEventTest {
 
         // Build and execute the request against the mock server.
         SiftRequest request = client.buildRequest(new CreateListingFieldSet()
-            .setApiKey("YOUR_API_KEY_HERE")
+            .setApiKey("_HERE")
             .setUserId("fyw3989sjpqr71")
             .setContentId("comment-23412")
             .setSessionId("a234ksjfgn435sfg")
@@ -253,7 +253,7 @@ public class ContentEventTest {
     public void testCreateMessage() throws Exception {
         String expectedRequestBody = "{\n" +
             "  \"$type\"       : \"$create_content\",\n" +
-            "  \"$api_key\"    : \"YOUR_API_KEY_HERE\",\n" +
+            "  \"$api_key\"    : \"_HERE\",\n" +
             "  \"$user_id\"    : \"fyw3989sjpqr71\",\n" +
             "  \"$content_id\"       : \"comment-23412\",\n" +
             "\n" +
@@ -287,7 +287,7 @@ public class ContentEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         Image image = new Image()
@@ -306,7 +306,7 @@ public class ContentEventTest {
 
         // Build and execute the request against the mock server.
         SiftRequest request = client.buildRequest(new CreateMessageFieldSet()
-            .setApiKey("YOUR_API_KEY_HERE")
+            .setApiKey("_HERE")
             .setUserId("fyw3989sjpqr71")
             .setContentId("comment-23412")
             .setSessionId("a234ksjfgn435sfg")
@@ -335,7 +335,7 @@ public class ContentEventTest {
     public void testCreateProfile() throws Exception {
         String expectedRequestBody = "{\n" +
             "  \"$type\"       : \"$create_content\",\n" +
-            "  \"$api_key\"    : \"YOUR_API_KEY_HERE\",\n" +
+            "  \"$api_key\"    : \"_HERE\",\n" +
             "  \"$user_id\"    : \"fyw3989sjpqr71\",\n" +
             "  \"$content_id\"       : \"comment-23412\",\n" +
             "\n" +
@@ -377,7 +377,7 @@ public class ContentEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         Image image = new Image()
@@ -405,7 +405,7 @@ public class ContentEventTest {
 
         // Build and execute the request against the mock server.
         SiftRequest request = client.buildRequest(new CreateProfileFieldSet()
-            .setApiKey("YOUR_API_KEY_HERE")
+            .setApiKey("_HERE")
             .setUserId("fyw3989sjpqr71")
             .setContentId("comment-23412")
             .setSessionId("a234ksjfgn435sfg")
@@ -434,7 +434,7 @@ public class ContentEventTest {
     public void testCreatePost() throws Exception {
         String expectedRequestBody = "{\n" +
             "  \"$type\"       : \"$create_content\",\n" +
-            "  \"$api_key\"    : \"YOUR_API_KEY_HERE\",\n" +
+            "  \"$api_key\"    : \"_HERE\",\n" +
             "  \"$user_id\"    : \"fyw3989sjpqr71\",\n" +
             "  \"$content_id\"       : \"comment-23412\",\n" +
             "\n" +
@@ -483,7 +483,7 @@ public class ContentEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         Image image = new Image()
@@ -521,7 +521,7 @@ public class ContentEventTest {
 
         // Build and execute the request against the mock server.
         SiftRequest request = client.buildRequest(new CreatePostFieldSet()
-            .setApiKey("YOUR_API_KEY_HERE")
+            .setApiKey("_HERE")
             .setUserId("fyw3989sjpqr71")
             .setContentId("comment-23412")
             .setSessionId("a234ksjfgn435sfg")
@@ -550,7 +550,7 @@ public class ContentEventTest {
     public void testCreateReview() throws Exception {
         String expectedRequestBody = "{\n" +
             "  \"$type\"       : \"$create_content\",\n" +
-            "  \"$api_key\"    : \"YOUR_API_KEY_HERE\",\n" +
+            "  \"$api_key\"    : \"_HERE\",\n" +
             "  \"$user_id\"    : \"fyw3989sjpqr71\",\n" +
             "  \"$content_id\"       : \"comment-23412\",\n" +
             "\n" +
@@ -593,7 +593,7 @@ public class ContentEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         Image image = new Image()
@@ -621,7 +621,7 @@ public class ContentEventTest {
 
         // Build and execute the request against the mock server.
         SiftRequest request = client.buildRequest(new CreateReviewFieldSet()
-            .setApiKey("YOUR_API_KEY_HERE")
+            .setApiKey("_HERE")
             .setUserId("fyw3989sjpqr71")
             .setContentId("comment-23412")
             .setSessionId("a234ksjfgn435sfg")
@@ -650,7 +650,7 @@ public class ContentEventTest {
     public void testUpdateComment() throws Exception {
         String expectedRequestBody = "{\n" +
             "  \"$type\"       : \"$update_content\",\n" +
-            "  \"$api_key\"    : \"YOUR_API_KEY_HERE\",\n" +
+            "  \"$api_key\"    : \"_HERE\",\n" +
             "  \"$user_id\"    : \"fyw3989sjpqr71\",\n" +
             "  \"$content_id\"       : \"comment-23412\",\n" +
             "\n" +
@@ -686,7 +686,7 @@ public class ContentEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         Image image = new Image()
@@ -706,7 +706,7 @@ public class ContentEventTest {
 
         // Build and execute the request against the mock server.
         SiftRequest request = client.buildRequest(new UpdateCommentFieldSet()
-            .setApiKey("YOUR_API_KEY_HERE")
+            .setApiKey("_HERE")
             .setUserId("fyw3989sjpqr71")
             .setContentId("comment-23412")
             .setSessionId("a234ksjfgn435sfg")
@@ -736,7 +736,7 @@ public class ContentEventTest {
     public void testUpdateListing() throws Exception {
         String expectedRequestBody = "{\n" +
             "  \"$type\"       : \"$update_content\",\n" +
-            "  \"$api_key\"    : \"YOUR_API_KEY_HERE\",\n" +
+            "  \"$api_key\"    : \"_HERE\",\n" +
             "  \"$user_id\"    : \"fyw3989sjpqr71\",\n" +
             "  \"$content_id\"       : \"comment-23412\",\n" +
             "\n" +
@@ -791,7 +791,7 @@ public class ContentEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         Image image = new Image()
@@ -833,7 +833,7 @@ public class ContentEventTest {
 
         // Build and execute the request against the mock server.
         SiftRequest request = client.buildRequest(new UpdateListingFieldSet()
-            .setApiKey("YOUR_API_KEY_HERE")
+            .setApiKey("_HERE")
             .setUserId("fyw3989sjpqr71")
             .setContentId("comment-23412")
             .setSessionId("a234ksjfgn435sfg")
@@ -862,7 +862,7 @@ public class ContentEventTest {
     public void testUpdateMessage() throws Exception {
         String expectedRequestBody = "{\n" +
             "  \"$type\"       : \"$update_content\",\n" +
-            "  \"$api_key\"    : \"YOUR_API_KEY_HERE\",\n" +
+            "  \"$api_key\"    : \"_HERE\",\n" +
             "  \"$user_id\"    : \"fyw3989sjpqr71\",\n" +
             "  \"$content_id\"       : \"comment-23412\",\n" +
             "\n" +
@@ -898,7 +898,7 @@ public class ContentEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         Image image = new Image()
@@ -919,7 +919,7 @@ public class ContentEventTest {
 
         // Build and execute the request against the mock server.
         SiftRequest request = client.buildRequest(new UpdateMessageFieldSet()
-            .setApiKey("YOUR_API_KEY_HERE")
+            .setApiKey("_HERE")
             .setUserId("fyw3989sjpqr71")
             .setContentId("comment-23412")
             .setSessionId("a234ksjfgn435sfg")
@@ -948,7 +948,7 @@ public class ContentEventTest {
     public void testUpdateProfile() throws Exception {
         String expectedRequestBody = "{\n" +
             "  \"$type\"       : \"$update_content\",\n" +
-            "  \"$api_key\"    : \"YOUR_API_KEY_HERE\",\n" +
+            "  \"$api_key\"    : \"_HERE\",\n" +
             "  \"$user_id\"    : \"fyw3989sjpqr71\",\n" +
             "  \"$content_id\"       : \"comment-23412\",\n" +
             "\n" +
@@ -990,7 +990,7 @@ public class ContentEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         Image image = new Image()
@@ -1018,7 +1018,7 @@ public class ContentEventTest {
 
         // Build and execute the request against the mock server.
         SiftRequest request = client.buildRequest(new UpdateProfileFieldSet()
-            .setApiKey("YOUR_API_KEY_HERE")
+            .setApiKey("_HERE")
             .setUserId("fyw3989sjpqr71")
             .setContentId("comment-23412")
             .setSessionId("a234ksjfgn435sfg")
@@ -1047,7 +1047,7 @@ public class ContentEventTest {
     public void testUpdatePost() throws Exception {
         String expectedRequestBody = "{\n" +
             "  \"$type\"       : \"$update_content\",\n" +
-            "  \"$api_key\"    : \"YOUR_API_KEY_HERE\",\n" +
+            "  \"$api_key\"    : \"_HERE\",\n" +
             "  \"$user_id\"    : \"fyw3989sjpqr71\",\n" +
             "  \"$content_id\"       : \"comment-23412\",\n" +
             "\n" +
@@ -1096,7 +1096,7 @@ public class ContentEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         Image image = new Image()
@@ -1134,7 +1134,7 @@ public class ContentEventTest {
 
         // Build and execute the request against the mock server.
         SiftRequest request = client.buildRequest(new UpdatePostFieldSet()
-            .setApiKey("YOUR_API_KEY_HERE")
+            .setApiKey("_HERE")
             .setUserId("fyw3989sjpqr71")
             .setContentId("comment-23412")
             .setSessionId("a234ksjfgn435sfg")
@@ -1163,7 +1163,7 @@ public class ContentEventTest {
     public void testUpdateReview() throws Exception {
         String expectedRequestBody = "{\n" +
             "  \"$type\"       : \"$update_content\",\n" +
-            "  \"$api_key\"    : \"YOUR_API_KEY_HERE\",\n" +
+            "  \"$api_key\"    : \"_HERE\",\n" +
             "  \"$user_id\"    : \"fyw3989sjpqr71\",\n" +
             "  \"$content_id\"       : \"comment-23412\",\n" +
             "\n" +
@@ -1206,7 +1206,7 @@ public class ContentEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         Image image = new Image()
@@ -1234,7 +1234,7 @@ public class ContentEventTest {
 
         // Build and execute the request against the mock server.
         SiftRequest request = client.buildRequest(new UpdateReviewFieldSet()
-            .setApiKey("YOUR_API_KEY_HERE")
+            .setApiKey("_HERE")
             .setUserId("fyw3989sjpqr71")
             .setContentId("comment-23412")
             .setSessionId("a234ksjfgn435sfg")

--- a/src/test/java/com/siftscience/ContentStatusEventTest.java
+++ b/src/test/java/com/siftscience/ContentStatusEventTest.java
@@ -39,7 +39,7 @@ public class ContentStatusEventTest {
 
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.

--- a/src/test/java/com/siftscience/ContentStatusEventTest.java
+++ b/src/test/java/com/siftscience/ContentStatusEventTest.java
@@ -16,7 +16,7 @@ public class ContentStatusEventTest {
     public void testContentStatus() throws Exception {
         String expectedRequestBody = "{\n" +
                 "  \"$type\"       : \"$content_status\",\n" +
-                "  \"$api_key\"    : \"your_api_key_here\",\n" +
+                "  \"$api_key\"    : \"\",\n" +
                 "  \"$user_id\"    : \"billy_jones_301\",\n" +
                 "  \"$content_id\" : \"9671500641\",\n" +
                 "  \"$status\"     : \"$paused\"\n" +
@@ -39,7 +39,7 @@ public class ContentStatusEventTest {
 
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.

--- a/src/test/java/com/siftscience/CreateAccountEventTest.java
+++ b/src/test/java/com/siftscience/CreateAccountEventTest.java
@@ -96,7 +96,7 @@ public class CreateAccountEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         // Payment methods.

--- a/src/test/java/com/siftscience/CreateAccountEventTest.java
+++ b/src/test/java/com/siftscience/CreateAccountEventTest.java
@@ -23,7 +23,7 @@ public class CreateAccountEventTest {
         String expectedRequestBody = "\n" +
                 "{\n" +
                 "  \"$type\"       : \"$create_account\",\n" +
-                "  \"$api_key\"    : \"your_api_key_here\",\n" +
+                "  \"$api_key\"    : \"\",\n" +
                 "  \"$user_id\"    : \"billy_jones_301\",\n" +
                 "\n" +
                 "  \"$session_id\"       : \"gigtleqddo84l8cm15qe4il\",\n" +
@@ -96,7 +96,7 @@ public class CreateAccountEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         // Payment methods.

--- a/src/test/java/com/siftscience/CreateOrderEventTest.java
+++ b/src/test/java/com/siftscience/CreateOrderEventTest.java
@@ -25,7 +25,7 @@ public class CreateOrderEventTest {
         // The expected JSON payload of the request.
         String expectedRequestBody = "{\n" +
                 "  \"$type\"             : \"$create_order\",\n" +
-                "  \"$api_key\"          : \"your_api_key_here\",\n" +
+                "  \"$api_key\"          : \"\",\n" +
                 "  \"$user_id\"          : \"billy_jones_301\",\n" +
                 "\n" +
                 "  \"$session_id\"       : \"gigtleqddo84l8cm15qe4il\",\n" +
@@ -128,7 +128,7 @@ public class CreateOrderEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         // Build the request body.

--- a/src/test/java/com/siftscience/CreateOrderEventTest.java
+++ b/src/test/java/com/siftscience/CreateOrderEventTest.java
@@ -128,7 +128,7 @@ public class CreateOrderEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         // Build the request body.

--- a/src/test/java/com/siftscience/CustomEventTest.java
+++ b/src/test/java/com/siftscience/CustomEventTest.java
@@ -37,7 +37,7 @@ public class CustomEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.

--- a/src/test/java/com/siftscience/CustomEventTest.java
+++ b/src/test/java/com/siftscience/CustomEventTest.java
@@ -16,7 +16,7 @@ public class CustomEventTest {
     public void testCustomEvent() throws Exception {
         String expectedRequestBody = "{\n" +
                 "  \"$type\"              : \"make_call\",\n" +
-                "  \"$api_key\"           : \"your_api_key_here\",\n" +
+                "  \"$api_key\"           : \"\",\n" +
                 "  \"$user_id\"           : \"billy_jones_301\",\n" +
                 "  \"recipient_user_id\"  : \"marylee819\",\n" +
                 "  \"call_duration\"      : 4428\n" +
@@ -37,7 +37,7 @@ public class CustomEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.

--- a/src/test/java/com/siftscience/DecisionStatusTest.java
+++ b/src/test/java/com/siftscience/DecisionStatusTest.java
@@ -65,13 +65,12 @@ public class DecisionStatusTest {
         baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key");
-        client.setBaseApi3Url(baseUrl);
+        SiftClient client = new SiftClient("your_api_key", "your_account_id");
+        client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.
         DecisionStatusRequest request = client.buildRequest(
                 new DecisionStatusFieldSet()
-                        .setAccountId("your_account_id")
                         .setEntity(DecisionStatusFieldSet.ENTITY_ORDERS)
                         .setEntityId("someid"));
         DecisionStatusResponse siftResponse = request.send();
@@ -114,13 +113,12 @@ public class DecisionStatusTest {
         baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key");
-        client.setBaseApi3Url(baseUrl);
+        SiftClient client = new SiftClient("your_api_key", "your_account_id");
+        client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.
         DecisionStatusRequest request = client.buildRequest(
             new DecisionStatusFieldSet()
-                .setAccountId("your_account_id")
                 .setEntity(DecisionStatusFieldSet.ENTITY_CONTENT)
                 .setEntityId("someid")
                 .setUserId("some_user"));

--- a/src/test/java/com/siftscience/DecisionStatusTest.java
+++ b/src/test/java/com/siftscience/DecisionStatusTest.java
@@ -65,7 +65,7 @@ public class DecisionStatusTest {
         baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key", "your_account_id");
+        SiftClient client = new SiftClient("YOUR_API_KEY", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.
@@ -78,7 +78,7 @@ public class DecisionStatusTest {
         // Verify the request.
         RecordedRequest request1 = server.takeRequest();
         Assert.assertEquals("GET", request1.getMethod());
-        Assert.assertEquals("/v3/accounts/your_account_id/orders/someid/decisions",
+        Assert.assertEquals("/v3/accounts/YOUR_ACCOUNT_ID/orders/someid/decisions",
                 request1.getPath());
         Assert.assertEquals(request1.getHeader("Authorization"), "Basic eW91cl9hcGlfa2V5Og==");
 
@@ -113,7 +113,7 @@ public class DecisionStatusTest {
         baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key", "your_account_id");
+        SiftClient client = new SiftClient("YOUR_API_KEY", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.
@@ -127,7 +127,7 @@ public class DecisionStatusTest {
         // Verify the request.
         RecordedRequest request1 = server.takeRequest();
         Assert.assertEquals("GET", request1.getMethod());
-        Assert.assertEquals("/v3/accounts/your_account_id/users/some_user/content/someid/decisions",
+        Assert.assertEquals("/v3/accounts/YOUR_ACCOUNT_ID/users/some_user/content/someid/decisions",
             request1.getPath());
         Assert.assertEquals(request1.getHeader("Authorization"), "Basic eW91cl9hcGlfa2V5Og==");
 

--- a/src/test/java/com/siftscience/FlagContentEventTest.java
+++ b/src/test/java/com/siftscience/FlagContentEventTest.java
@@ -39,7 +39,7 @@ public class FlagContentEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.

--- a/src/test/java/com/siftscience/FlagContentEventTest.java
+++ b/src/test/java/com/siftscience/FlagContentEventTest.java
@@ -16,7 +16,7 @@ public class FlagContentEventTest {
     public void testFlagContent() throws Exception {
         String expectedRequestBody = "{\n" +
                 "  \"$type\"       : \"$flag_content\", \n" +
-                "  \"$api_key\"    : \"your_api_key_here\",\n" +
+                "  \"$api_key\"    : \"\",\n" +
                 "  \"$user_id\"    : \"billy_jones_301\",\n" +
                 "  \"$content_id\" : \"9671500641\",\n" +
                 "\n" +
@@ -39,7 +39,7 @@ public class FlagContentEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.

--- a/src/test/java/com/siftscience/GetDecisionsTest.java
+++ b/src/test/java/com/siftscience/GetDecisionsTest.java
@@ -58,7 +58,7 @@ public class GetDecisionsTest {
         baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key", accountId);
+        SiftClient client = new SiftClient("YOUR_API_KEY", accountId);
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.
@@ -128,7 +128,7 @@ public class GetDecisionsTest {
         baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key", accountId);
+        SiftClient client = new SiftClient("YOUR_API_KEY", accountId);
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.

--- a/src/test/java/com/siftscience/GetDecisionsTest.java
+++ b/src/test/java/com/siftscience/GetDecisionsTest.java
@@ -58,12 +58,11 @@ public class GetDecisionsTest {
         baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key");
-        client.setBaseApi3Url(baseUrl);
+        SiftClient client = new SiftClient("your_api_key", accountId);
+        client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.
         GetDecisionsRequest getDecisionsRequest = client.buildRequest(new GetDecisionFieldSet()
-                .setAccountId(accountId)
                 .setLimit(11)
                 .setAbuseTypes(Arrays.asList(ACCOUNT_ABUSE, ACCOUNT_TAKEOVER))
                 .setFrom(1)
@@ -86,8 +85,7 @@ public class GetDecisionsTest {
         JSONAssert.assertEquals(response.getBody().readUtf8(),
                 siftResponse.getBody().toJson(), true);
 
-        GetDecisionsRequest nextRequest = client.buildRequest(GetDecisionFieldSet.fromNextRef(
-                siftResponse.getBody().getNextRef()));
+        client.buildRequest(GetDecisionFieldSet.fromNextRef(siftResponse.getBody().getNextRef()));
     }
 
     @Test
@@ -130,12 +128,11 @@ public class GetDecisionsTest {
         baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key");
-        client.setBaseApi3Url(baseUrl);
+        SiftClient client = new SiftClient("your_api_key", accountId);
+        client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.
         GetDecisionsRequest getDecisionsRequest = client.buildRequest(new GetDecisionFieldSet()
-                .setAccountId(accountId)
                 .setLimit(11)
                 .setAbuseTypes(Arrays.asList(ACCOUNT_ABUSE, ACCOUNT_TAKEOVER))
                 .setFrom(1)

--- a/src/test/java/com/siftscience/LabelTest.java
+++ b/src/test/java/com/siftscience/LabelTest.java
@@ -40,7 +40,7 @@ public class LabelTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("23b87a99k099fc98");
+        SiftClient client = new SiftClient("23b87a99k099fc98", "account_id");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.

--- a/src/test/java/com/siftscience/LinkSessionToUserEventTest.java
+++ b/src/test/java/com/siftscience/LinkSessionToUserEventTest.java
@@ -36,7 +36,7 @@ public class LinkSessionToUserEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("209f490k25lb9021");
+        SiftClient client = new SiftClient("209f490k25lb9021", "account_id");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.

--- a/src/test/java/com/siftscience/LoginEventTest.java
+++ b/src/test/java/com/siftscience/LoginEventTest.java
@@ -53,7 +53,7 @@ public class LoginEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.
@@ -115,7 +115,7 @@ public class LoginEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.

--- a/src/test/java/com/siftscience/LoginEventTest.java
+++ b/src/test/java/com/siftscience/LoginEventTest.java
@@ -25,7 +25,7 @@ public class LoginEventTest {
 
         String expectedRequestBody = "{\n" +
                 "  \"$type\"         : \"$login\",\n" +
-                "  \"$api_key\"      : \"your_api_key_here\",\n" +
+                "  \"$api_key\"      : \"\",\n" +
                 "  \"$user_id\"      : \"billy_jones_301\",\n" +
                 "  \"$login_status\" : \"$success\",\n" +
                 "  \"$app\"          : {\n" +
@@ -53,7 +53,7 @@ public class LoginEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.
@@ -92,7 +92,7 @@ public class LoginEventTest {
 
         String expectedRequestBody = "{\n" +
                 "  \"$type\"         : \"$login\",\n" +
-                "  \"$api_key\"      : \"your_api_key_here\",\n" +
+                "  \"$api_key\"      : \"\",\n" +
                 "  \"$user_id\"      : \"billy_jones_301\",\n" +
                 "  \"$login_status\" : \"$success\",\n" +
                 "  \"$browser\"          : {\n" +
@@ -115,7 +115,7 @@ public class LoginEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.

--- a/src/test/java/com/siftscience/LogoutEventTest.java
+++ b/src/test/java/com/siftscience/LogoutEventTest.java
@@ -35,7 +35,7 @@ public class LogoutEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("209f490k25lb9021");
+        SiftClient client = new SiftClient("209f490k25lb9021", "account_id");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.

--- a/src/test/java/com/siftscience/OrderStatusEventTest.java
+++ b/src/test/java/com/siftscience/OrderStatusEventTest.java
@@ -16,7 +16,7 @@ public class OrderStatusEventTest {
     public void testOrderStatus() throws Exception {
         String expectedRequestBody = "{\n" +
                 "  \"$type\"             : \"$order_status\",\n" +
-                "  \"$api_key\"          : \"your_api_key_here\",\n" +
+                "  \"$api_key\"          : \"\",\n" +
                 "  \"$user_id\"          : \"billy_jones_301\",\n" +
                 "  \"$order_id\"         : \"ORDER-28168441\",\n" +
                 "  \"$order_status\"     : \"$canceled\",\n" +
@@ -43,7 +43,7 @@ public class OrderStatusEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.

--- a/src/test/java/com/siftscience/OrderStatusEventTest.java
+++ b/src/test/java/com/siftscience/OrderStatusEventTest.java
@@ -43,7 +43,7 @@ public class OrderStatusEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.

--- a/src/test/java/com/siftscience/RemoveItemFromCartEventTest.java
+++ b/src/test/java/com/siftscience/RemoveItemFromCartEventTest.java
@@ -16,7 +16,7 @@ public class RemoveItemFromCartEventTest {
     public void testRemoveItemFromCart() throws Exception {
         String expectedRequestBody = "{\n" +
                 "  \"$type\"       : \"$remove_item_from_cart\",\n" +
-                "  \"$api_key\"    : \"your_api_key_here\",\n" +
+                "  \"$api_key\"    : \"\",\n" +
                 "  \"$user_id\"    : \"billy_jones_301\",\n" +
                 "\n" +
                 "  \"$session_id\" : \"gigtleqddo84l8cm15qe4il\",\n" +
@@ -50,7 +50,7 @@ public class RemoveItemFromCartEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.

--- a/src/test/java/com/siftscience/RemoveItemFromCartEventTest.java
+++ b/src/test/java/com/siftscience/RemoveItemFromCartEventTest.java
@@ -50,7 +50,7 @@ public class RemoveItemFromCartEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.

--- a/src/test/java/com/siftscience/ScoresTest.java
+++ b/src/test/java/com/siftscience/ScoresTest.java
@@ -23,7 +23,7 @@ public class ScoresTest {
         // The expected JSON payload of the request.
         String expectedRequestBody = "{\n" +
                 "  \"$type\"             : \"$create_order\",\n" +
-                "  \"$api_key\"          : \"your_api_key_here\",\n" +
+                "  \"$api_key\"          : \"\",\n" +
                 "  \"$user_id\"          : \"billy_jones_301\"\n" +
                 "}";
 
@@ -77,7 +77,7 @@ public class ScoresTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.
@@ -109,7 +109,7 @@ public class ScoresTest {
         // The expected JSON payload of the request.
         String expectedRequestBody = "{\n" +
                 "  \"$type\"             : \"$create_order\",\n" +
-                "  \"$api_key\"          : \"your_api_key_here\",\n" +
+                "  \"$api_key\"          : \"\",\n" +
                 "  \"$user_id\"          : \"billy_jones_301\"\n" +
                 "}";
 
@@ -163,7 +163,7 @@ public class ScoresTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.
@@ -234,7 +234,7 @@ public class ScoresTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         List<String> abuseTypes = new ArrayList<>();
@@ -250,7 +250,7 @@ public class ScoresTest {
         // Verify the request.
         RecordedRequest request1 = server.takeRequest();
         Assert.assertEquals("GET", request1.getMethod());
-        Assert.assertEquals("/v205/score/billy_jones_301?api_key=your_api_key_here&" +
+        Assert.assertEquals("/v205/score/billy_jones_301?api_key=&" +
                 "abuse_types=payment_abuse,promotion_abuse", request1.getPath());
 
         // Verify the response.

--- a/src/test/java/com/siftscience/ScoresTest.java
+++ b/src/test/java/com/siftscience/ScoresTest.java
@@ -77,7 +77,7 @@ public class ScoresTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.
@@ -163,7 +163,7 @@ public class ScoresTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.
@@ -234,7 +234,7 @@ public class ScoresTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         List<String> abuseTypes = new ArrayList<>();

--- a/src/test/java/com/siftscience/SecurityNotificationEventTest.java
+++ b/src/test/java/com/siftscience/SecurityNotificationEventTest.java
@@ -46,7 +46,7 @@ public class SecurityNotificationEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.

--- a/src/test/java/com/siftscience/SecurityNotificationEventTest.java
+++ b/src/test/java/com/siftscience/SecurityNotificationEventTest.java
@@ -23,7 +23,7 @@ public class SecurityNotificationEventTest {
 
         String expectedRequestBody = "{\n" +
                 "  \"$type\"         : \"$security_notification\",\n" +
-                "  \"$api_key\"      : \"your_api_key_here\",\n" +
+                "  \"$api_key\"      : \"\",\n" +
                 "  \"$user_id\"      : \"billy_jones_301\",\n" +
                 "  \"$session_id\"   : \"" + sessionId + "\",\n" +
                 "  \"$notification_status\"       : \"$sent\",\n" +
@@ -46,7 +46,7 @@ public class SecurityNotificationEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.

--- a/src/test/java/com/siftscience/SessionDecisionStatusTest.java
+++ b/src/test/java/com/siftscience/SessionDecisionStatusTest.java
@@ -39,13 +39,12 @@ public class SessionDecisionStatusTest {
         baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key");
-        client.setBaseApi3Url(baseUrl);
+        SiftClient client = new SiftClient("your_api_key", "your_account_id");
+        client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.
         DecisionStatusRequest request = client.buildRequest(
             new DecisionStatusFieldSet()
-                .setAccountId("your_account_id")
                 .setUserId("someuser")
                 .setEntity(DecisionStatusFieldSet.ENTITY_SESSIONS)
                 .setEntityId("someid"));

--- a/src/test/java/com/siftscience/SessionDecisionStatusTest.java
+++ b/src/test/java/com/siftscience/SessionDecisionStatusTest.java
@@ -39,7 +39,7 @@ public class SessionDecisionStatusTest {
         baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key", "your_account_id");
+        SiftClient client = new SiftClient("YOUR_API_KEY", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.
@@ -53,7 +53,7 @@ public class SessionDecisionStatusTest {
         // Verify the request.
         RecordedRequest request1 = server.takeRequest();
         Assert.assertEquals("GET", request1.getMethod());
-        Assert.assertEquals("/v3/accounts/your_account_id/users/someuser/sessions/someid/decisions",
+        Assert.assertEquals("/v3/accounts/YOUR_ACCOUNT_ID/users/someuser/sessions/someid/decisions",
             request1.getPath());
         Assert.assertEquals(request1.getHeader("Authorization"), "Basic eW91cl9hcGlfa2V5Og==");
 

--- a/src/test/java/com/siftscience/SiftClientTest.java
+++ b/src/test/java/com/siftscience/SiftClientTest.java
@@ -34,7 +34,7 @@ public class SiftClientTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        client = new SiftClient("some_api_key");
+        client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
     }
 

--- a/src/test/java/com/siftscience/SiftClientTest.java
+++ b/src/test/java/com/siftscience/SiftClientTest.java
@@ -34,7 +34,7 @@ public class SiftClientTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        client = new SiftClient("your_api_key_here", "your_account_id_here");
+        client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
     }
 
@@ -103,7 +103,7 @@ public class SiftClientTest {
 
         String expectedRequestBody = "{\n" +
                 "  \"$type\"             : \"$create_order\",\n" +
-                "  \"$api_key\"          : \"your_api_key\",\n" +
+                "  \"$api_key\"          : \"YOUR_API_KEY\",\n" +
                 "  \"$user_id\"          : \"billy_jones_301\",\n" +
                 "  \"$order_id\"          : \"ORDER-28168441\"\n" +
                 "}";

--- a/src/test/java/com/siftscience/TestUtils.java
+++ b/src/test/java/com/siftscience/TestUtils.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public class TestUtils {
     static String unescapeJson(String json) {
-        return json.replaceAll("\\\"", "\\\\\"").replaceAll("\n", "");
+        return json.replaceAll("\"", "\\\\\"").replaceAll("\n", "");
     }
 
     static Address sampleAddress1() {

--- a/src/test/java/com/siftscience/TransactionEventTest.java
+++ b/src/test/java/com/siftscience/TransactionEventTest.java
@@ -16,7 +16,7 @@ public class TransactionEventTest {
     public void testTransactionEvent() throws Exception {
         String expectedRequestBody = "{\n" +
                 "  \"$type\"             : \"$transaction\",\n" +
-                "  \"$api_key\"          : \"your_api_key_here\",\n" +
+                "  \"$api_key\"          : \"\",\n" +
                 "  \"$user_id\"          : \"billy_jones_301\",\n" +
                 "  \"$amount\"           : 506790000,\n" +
                 "  \"$currency_code\"    : \"USD\",\n" +
@@ -78,7 +78,7 @@ public class TransactionEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.

--- a/src/test/java/com/siftscience/TransactionEventTest.java
+++ b/src/test/java/com/siftscience/TransactionEventTest.java
@@ -78,7 +78,7 @@ public class TransactionEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.

--- a/src/test/java/com/siftscience/UnlabelTest.java
+++ b/src/test/java/com/siftscience/UnlabelTest.java
@@ -1,6 +1,7 @@
 package com.siftscience;
 
-import com.siftscience.model.ChargebackFieldSet;
+import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
+
 import com.siftscience.model.UnlabelFieldSet;
 import okhttp3.HttpUrl;
 import okhttp3.mockwebserver.MockResponse;
@@ -8,8 +9,6 @@ import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Assert;
 import org.junit.Test;
-
-import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
 
 public class UnlabelTest {
     @Test
@@ -24,7 +23,7 @@ public class UnlabelTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("23b87a99k099fc98");
+        SiftClient client = new SiftClient("23b87a99k099fc98", "dummy_account_id");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.
@@ -57,7 +56,7 @@ public class UnlabelTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("23b87a99k099fc98");
+        SiftClient client = new SiftClient("23b87a99k099fc98", "dummy_account_id");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.

--- a/src/test/java/com/siftscience/UpdateAccountEventTest.java
+++ b/src/test/java/com/siftscience/UpdateAccountEventTest.java
@@ -22,7 +22,7 @@ public class UpdateAccountEventTest {
         String expectedRequestBody = "\n" +
                 "{\n" +
                 "  \"$type\"       : \"$update_account\",\n" +
-                "  \"$api_key\"    : \"your_api_key_here\",\n" +
+                "  \"$api_key\"    : \"\",\n" +
                 "  \"$user_id\"    : \"billy_jones_301\",\n" +
                 "  \"$changed_password\" : true,\n" +
                 "  \"$user_email\"       : \"bill@gmail.com\",\n" +
@@ -77,7 +77,7 @@ public class UpdateAccountEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         // Payment methods.

--- a/src/test/java/com/siftscience/UpdateAccountEventTest.java
+++ b/src/test/java/com/siftscience/UpdateAccountEventTest.java
@@ -77,7 +77,7 @@ public class UpdateAccountEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         // Payment methods.

--- a/src/test/java/com/siftscience/UpdateOrderEventTest.java
+++ b/src/test/java/com/siftscience/UpdateOrderEventTest.java
@@ -24,7 +24,7 @@ public class UpdateOrderEventTest {
         // The expected JSON payload of the request.
         String expectedRequestBody = "{\n" +
                 "  \"$type\"             : \"$update_order\",\n" +
-                "  \"$api_key\"          : \"your_api_key_here\",\n" +
+                "  \"$api_key\"          : \"\",\n" +
                 "  \"$user_id\"          : \"billy_jones_301\",\n" +
                 "\n" +
                 "  \"$session_id\"       : \"gigtleqddo84l8cm15qe4il\",\n" +
@@ -127,7 +127,7 @@ public class UpdateOrderEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         // Build the request body.

--- a/src/test/java/com/siftscience/UpdateOrderEventTest.java
+++ b/src/test/java/com/siftscience/UpdateOrderEventTest.java
@@ -127,7 +127,7 @@ public class UpdateOrderEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         // Build the request body.

--- a/src/test/java/com/siftscience/UpdatePasswordEventTest.java
+++ b/src/test/java/com/siftscience/UpdatePasswordEventTest.java
@@ -21,7 +21,7 @@ public class UpdatePasswordEventTest {
     public void testUpdatePassword() throws Exception {
         String expectedRequestBody = "{\n" +
                 "  \"$type\"         : \"$update_password\",\n" +
-                "  \"$api_key\"      : \"your_api_key_here\",\n" +
+                "  \"$api_key\"      : \"\",\n" +
                 "  \"$user_id\"      : \"billy_jones_301\",\n" +
                 "  \"$session_id\" : \"gigtleqddo84l8cm15qe4il\",\n" +
                 "  \"$app\"          : {\n" +
@@ -51,7 +51,7 @@ public class UpdatePasswordEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.

--- a/src/test/java/com/siftscience/UpdatePasswordEventTest.java
+++ b/src/test/java/com/siftscience/UpdatePasswordEventTest.java
@@ -51,7 +51,7 @@ public class UpdatePasswordEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.

--- a/src/test/java/com/siftscience/UserScoreTest.java
+++ b/src/test/java/com/siftscience/UserScoreTest.java
@@ -81,7 +81,7 @@ public class UserScoreTest {
                 .setRescoreUser(false);
 
         testUserScore(userScoreFieldSet,
-                "/v205/users/billy_jones_301/score?api_key=your_api_key_here");
+                "/v205/users/billy_jones_301/score?api_key=");
     }
 
     @Test
@@ -97,7 +97,7 @@ public class UserScoreTest {
                         .setRescoreUser(false);
 
         testUserScore(userScoreFieldSet,
-                "/v205/users/billy_jones_301/score?api_key=your_api_key_here&" +
+                "/v205/users/billy_jones_301/score?api_key=&" +
                 "abuse_types=payment_abuse,promotion_abuse");
     }
 
@@ -110,7 +110,7 @@ public class UserScoreTest {
                 .setRescoreUser(true);
 
         testUserScore(userScoreFieldSet,
-                "/v205/users/billy_jones_301/score?api_key=your_api_key_here");
+                "/v205/users/billy_jones_301/score?api_key=");
     }
 
     @Test
@@ -126,7 +126,7 @@ public class UserScoreTest {
                 .setRescoreUser(true);
 
         testUserScore(userScoreFieldSet,
-                "/v205/users/billy_jones_301/score?api_key=your_api_key_here&" +
+                "/v205/users/billy_jones_301/score?api_key=&" +
                         "abuse_types=payment_abuse,promotion_abuse");
     }
 
@@ -147,7 +147,7 @@ public class UserScoreTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         UserScoreRequest request = client.buildRequest(userScoreFieldSet);

--- a/src/test/java/com/siftscience/UserScoreTest.java
+++ b/src/test/java/com/siftscience/UserScoreTest.java
@@ -147,7 +147,7 @@ public class UserScoreTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         UserScoreRequest request = client.buildRequest(userScoreFieldSet);

--- a/src/test/java/com/siftscience/VerificationEventTest.java
+++ b/src/test/java/com/siftscience/VerificationEventTest.java
@@ -59,7 +59,7 @@ public class VerificationEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.

--- a/src/test/java/com/siftscience/VerificationEventTest.java
+++ b/src/test/java/com/siftscience/VerificationEventTest.java
@@ -24,7 +24,7 @@ public class VerificationEventTest {
 
         String expectedRequestBody = "{\n" +
                 "  \"$type\"         : \"$verification\",\n" +
-                "  \"$api_key\"      : \"your_api_key_here\",\n" +
+                "  \"$api_key\"      : \"\",\n" +
                 "  \"$user_id\"      : \"billy_jones_301\",\n" +
                 "  \"$session_id\"   : \"" + sessionId + "\",\n" +
                 "  \"$app\"          : {\n" +
@@ -59,7 +59,7 @@ public class VerificationEventTest {
         HttpUrl baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.

--- a/src/test/java/com/siftscience/WorkflowStatusTest.java
+++ b/src/test/java/com/siftscience/WorkflowStatusTest.java
@@ -124,7 +124,7 @@ public class WorkflowStatusTest {
         baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here");
+        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.
@@ -212,13 +212,12 @@ public class WorkflowStatusTest {
         baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key");
-        client.setBaseApi3Url(baseUrl);
+        SiftClient client = new SiftClient("your_api_key", "your_account_id");
+        client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.
         WorkflowStatusRequest request = client.buildRequest(
-                new WorkflowStatusFieldSet().setAccountId("your_account_id")
-                        .setWorkflowRunId("someid"));
+                new WorkflowStatusFieldSet().setWorkflowRunId("someid"));
         WorkflowStatusResponse siftResponse = request.send();
 
         // Verify the request.

--- a/src/test/java/com/siftscience/WorkflowStatusTest.java
+++ b/src/test/java/com/siftscience/WorkflowStatusTest.java
@@ -19,7 +19,7 @@ public class WorkflowStatusTest {
         // The expected JSON payload of the request.
         String expectedRequestBody = "{\n" +
                 "  \"$type\"             : \"$create_order\",\n" +
-                "  \"$api_key\"          : \"your_api_key_here\",\n" +
+                "  \"$api_key\"          : \"\",\n" +
                 "  \"$user_id\"          : \"billy_jones_301\"\n" +
                 "}";
 
@@ -124,7 +124,7 @@ public class WorkflowStatusTest {
         baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key_here", "your_account_id_here");
+        SiftClient client = new SiftClient("", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.
@@ -212,7 +212,7 @@ public class WorkflowStatusTest {
         baseUrl = server.url("");
 
         // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("your_api_key", "your_account_id");
+        SiftClient client = new SiftClient("YOUR_API_KEY", "YOUR_ACCOUNT_ID");
         client.setBaseUrl(baseUrl);
 
         // Build and execute the request against the mock server.
@@ -223,7 +223,7 @@ public class WorkflowStatusTest {
         // Verify the request.
         RecordedRequest request1 = server.takeRequest();
         Assert.assertEquals("GET", request1.getMethod());
-        Assert.assertEquals("/v3/accounts/your_account_id/workflows/runs/someid",
+        Assert.assertEquals("/v3/accounts/YOUR_ACCOUNT_ID/workflows/runs/someid",
                 request1.getPath());
         Assert.assertEquals(request1.getHeader("Authorization"), "Basic eW91cl9hcGlfa2V5Og==");
 


### PR DESCRIPTION
Currently, you can set `account_id` per request. Because `SiftClient` is initialized with an api key, the client is actually tied to a single account_id, so pass `account_id` to the `SiftClient` constructor and remove `account_id` from per-request parameter classes.