### PR TITLE
(For David) adding support for  bookings complex field in $create_order and $update_order events

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'signing'
 apply plugin: 'java-library-distribution'
 
 group = 'com.siftscience'
-version = '3.0.0'
+version = '3.1.0'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/siftscience/model/BaseOrderFieldSet.java
+++ b/src/main/java/com/siftscience/model/BaseOrderFieldSet.java
@@ -19,6 +19,7 @@ public abstract class BaseOrderFieldSet<T extends BaseOrderFieldSet<T>>
     @Expose @SerializedName("$seller_user_id") private String sellerUserId;
     @Expose @SerializedName("$promotions") private List<Promotion> promotions;
     @Expose @SerializedName("$shipping_method") private String shippingMethod;
+    @Expose @SerializedName("$bookings") private List<Booking> bookings;
 
     public String getOrderId() {
         return orderId;
@@ -102,6 +103,15 @@ public abstract class BaseOrderFieldSet<T extends BaseOrderFieldSet<T>>
 
     public T setItems(List<Item> items) {
         this.items = items;
+        return (T) this;
+    }
+
+    public List<Booking> getBookings() {
+        return bookings;
+    }
+
+    public T setBookings(List<Booking> bookings) {
+        this.bookings = bookings;
         return (T) this;
     }
 

--- a/src/main/java/com/siftscience/model/Booking.java
+++ b/src/main/java/com/siftscience/model/Booking.java
@@ -1,0 +1,149 @@
+package com.siftscience.model;
+
+import java.util.List;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+public class Booking {
+    @Expose @SerializedName("$booking_type") private String bookingType;
+    @Expose @SerializedName("$title") private String title;
+    @Expose @SerializedName("$start_time") private Long startTime;
+    @Expose @SerializedName("$end_time") private Long endTime;
+    @Expose @SerializedName("$price") private Long price;
+    @Expose @SerializedName("$currency_code") private String currencyCode;
+    @Expose @SerializedName("$quantity") private Long quantity;
+    @Expose @SerializedName("$guests") private List<Guest> guests;
+    @Expose @SerializedName("$segments") private List<Segment> segments;
+    @Expose @SerializedName("$room_type") private String roomType;
+    @Expose @SerializedName("$event_id") private String eventId;
+    @Expose @SerializedName("$venue_id") private String venueId;
+    @Expose @SerializedName("$location") private String location;
+    @Expose @SerializedName("$category") private String category;
+
+    public String getBookingType() {
+        return bookingType;
+    }
+
+    public Booking setBookingType(String bookingType) {
+        this.bookingType = bookingType;
+        return this;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public Booking setTitle(String title) {
+        this.title = title;
+        return this;
+    }
+
+    public Long getStartTime() {
+        return startTime;
+    }
+
+    public Booking setStartTime(Long startTime) {
+        this.startTime = startTime;
+        return this;
+    }
+
+    public Long getEndTime() {
+        return endTime;
+    }
+
+    public Booking setEndTime(Long endTime) {
+        this.endTime = endTime;
+        return this;
+    }
+
+    public Long getPrice() {
+        return price;
+    }
+
+    public Booking setPrice(Long price) {
+        this.price = price;
+        return this;
+    }
+
+    public String getCurrencyCode() {
+        return currencyCode;
+    }
+
+    public Booking setCurrencyCode(String currencyCode) {
+        this.currencyCode = currencyCode;
+        return this;
+    }
+
+    public Long getQuantity() {
+        return quantity;
+    }
+
+    public Booking setQuantity(Long quantity) {
+        this.quantity = quantity;
+        return this;
+    }
+
+    public List<Guest> getGuests() {
+        return guests;
+    }
+
+    public Booking setGuests(List<Guest> guests) {
+        this.guests = guests;
+        return this;
+    }
+
+    public List<Segment> getSegments() {
+        return segments;
+    }
+
+    public Booking setSegments(List<Segment> segments) {
+        this.segments = segments;
+        return this;
+    }
+
+    public String getRoomType() {
+        return roomType;
+    }
+
+    public Booking setRoomType(String roomType) {
+        this.roomType = roomType;
+        return this;
+    }
+
+    public String getEventId() {
+        return eventId;
+    }
+
+    public Booking setEventId(String eventId) {
+        this.eventId = eventId;
+        return this;
+    }
+
+    public String getVenueId() {
+        return venueId;
+    }
+
+    public Booking setVenueId(String venueId) {
+        this.venueId = venueId;
+        return this;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public Booking setLocation(String location) {
+        this.location = location;
+        return this;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public Booking setCategory(String category) {
+        this.category = category;
+        return this;
+    }
+}

--- a/src/main/java/com/siftscience/model/Booking.java
+++ b/src/main/java/com/siftscience/model/Booking.java
@@ -18,7 +18,7 @@ public class Booking {
     @Expose @SerializedName("$room_type") private String roomType;
     @Expose @SerializedName("$event_id") private String eventId;
     @Expose @SerializedName("$venue_id") private String venueId;
-    @Expose @SerializedName("$location") private String location;
+    @Expose @SerializedName("$location") private Address location;
     @Expose @SerializedName("$category") private String category;
 
     public String getBookingType() {
@@ -129,11 +129,11 @@ public class Booking {
         return this;
     }
 
-    public String getLocation() {
+    public Address getLocation() {
         return location;
     }
 
-    public Booking setLocation(String location) {
+    public Booking setLocation(Address location) {
         this.location = location;
         return this;
     }

--- a/src/main/java/com/siftscience/model/Guest.java
+++ b/src/main/java/com/siftscience/model/Guest.java
@@ -1,0 +1,67 @@
+package com.siftscience.model;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+public class Guest {
+    @Expose @SerializedName("$name") private String name;
+    @Expose @SerializedName("$email") private String email;
+    @Expose @SerializedName("$phone") private String phone;
+    @Expose @SerializedName("$loyalty_program") private String loyaltyProgram;
+    @Expose @SerializedName("$loyalty_program_id") private String loyaltyProgramId;
+    @Expose @SerializedName("$birth_date") private String birthDate;
+
+    public String getName() {
+        return name;
+    }
+
+    public Guest setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public Guest setEmail(String email) {
+        this.email = email;
+        return this;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public Guest setPhone(String phone) {
+        this.phone = phone;
+        return this;
+    }
+
+    public String getLoyaltyProgram() {
+        return loyaltyProgram;
+    }
+
+    public Guest setLoyaltyProgram(String loyaltyProgram) {
+        this.loyaltyProgram = loyaltyProgram;
+        return this;
+    }
+
+    public String getLoyaltyProgramId() {
+        return loyaltyProgramId;
+    }
+
+    public Guest setLoyaltyProgramId(String loyaltyProgramId) {
+        this.loyaltyProgramId = loyaltyProgramId;
+        return this;
+    }
+
+    public String getBirthDate() {
+        return birthDate;
+    }
+
+    public Guest setBirthDate(String birthDate) {
+        this.birthDate = birthDate;
+        return this;
+    }
+}

--- a/src/main/java/com/siftscience/model/Segment.java
+++ b/src/main/java/com/siftscience/model/Segment.java
@@ -1,0 +1,88 @@
+package com.siftscience.model;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+public class Segment {
+    @Expose @SerializedName("$departure_address") private Address departureAddress;
+    @Expose @SerializedName("$arrival_address") private Address arrivalAddress;
+    @Expose @SerializedName("$start_time") private Long startTime;
+    @Expose @SerializedName("$end_time") private Long endTime;
+    @Expose @SerializedName("$vessel_number") private String vesselNumber;
+    @Expose @SerializedName("$arrival_airport_code") private String arrivalAirportCode;
+    @Expose @SerializedName("$departure_airport_code") private String departureAirportCode;
+    @Expose @SerializedName("$fare_class") private String fareClass;
+
+
+    public Address getDepartureAddress() {
+        return departureAddress;
+    }
+
+    public Segment setDepartureAddress(Address departureAddress) {
+        this.departureAddress = departureAddress;
+        return this;
+    }
+
+    public Address getArrivalAddress() {
+        return arrivalAddress;
+    }
+
+    public Segment setArrivalAddress(Address arrivalAddress) {
+        this.arrivalAddress = arrivalAddress;
+        return this;
+    }
+
+    public Long getStartTime() {
+        return startTime;
+    }
+
+    public Segment setStartTime(Long startTime) {
+        this.startTime = startTime;
+        return this;
+    }
+
+    public Long getEndTime() {
+        return endTime;
+    }
+
+    public Segment setEndTime(Long endTime) {
+        this.endTime = endTime;
+        return this;
+    }
+
+    public String getVesselNumber() {
+        return vesselNumber;
+    }
+
+    public Segment setVesselNumber(String vesselNumber) {
+        this.vesselNumber = vesselNumber;
+        return this;
+    }
+
+    public String getArrivalAirportCode() {
+        return arrivalAirportCode;
+    }
+
+    public Segment setArrivalAirportCode(String arrivalAirportCode) {
+        this.arrivalAirportCode = arrivalAirportCode;
+        return this;
+    }
+
+    public String getDepartureAirportCode() {
+        return departureAirportCode;
+    }
+
+    public Segment setDepartureAirportCode(String departureAirportCode) {
+        this.departureAirportCode = departureAirportCode;
+        return this;
+    }
+
+    public String getFareClass() {
+        return fareClass;
+    }
+
+    public Segment setFareClass(String fareClass) {
+        this.fareClass = fareClass;
+        return this;
+    }
+}

--- a/src/test/java/com/siftscience/CreateOrderEventWithBookingsTest.java
+++ b/src/test/java/com/siftscience/CreateOrderEventWithBookingsTest.java
@@ -1,0 +1,216 @@
+package com.siftscience;
+
+import static java.net.HttpURLConnection.HTTP_OK;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.siftscience.model.Booking;
+import com.siftscience.model.CreateOrderFieldSet;
+import com.siftscience.model.PaymentMethod;
+import com.siftscience.model.Promotion;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.json.JSONException;
+import org.junit.Assert;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+public class CreateOrderEventWithBookingsTest {
+
+    @Test
+    public void testCreateOrderEvent() throws JSONException, IOException,
+        InterruptedException {
+
+        // The expected JSON payload of the request.
+        String expectedRequestBody = "{\n" +
+            "  \"$type\"             : \"$create_order\",\n" +
+            "  \"$api_key\"          : \"YOUR_API_KEY\",\n" +
+            "  \"$user_id\"          : \"billy_jones_301\",\n" +
+            "\n" +
+            "  \"$session_id\"       : \"gigtleqddo84l8cm15qe4il\",\n" +
+            "  \"$order_id\"         : \"ORDER-28168441\",\n" +
+            "  \"$user_email\"       : \"bill@gmail.com\",\n" +
+            "  \"$amount\"           : 115940000,\n" +
+            "  \"$currency_code\"    : \"USD\",\n" +
+            "  \"$billing_address\"  : {\n" +
+            "      \"$name\"         : \"Bill Jones\",\n" +
+            "      \"$phone\"        : \"1-415-555-6041\",\n" +
+            "      \"$address_1\"    : \"2100 Main Street\",\n" +
+            "      \"$address_2\"    : \"Apt 3B\",\n" +
+            "      \"$city\"         : \"New London\",\n" +
+            "      \"$region\"       : \"New Hampshire\",\n" +
+            "      \"$country\"      : \"US\",\n" +
+            "      \"$zipcode\"      : \"03257\"\n" +
+            "  },\n" +
+            "  \"$payment_methods\"  : [\n" +
+            "      {\n" +
+            "          \"$payment_type\"    : \"$credit_card\",\n" +
+            "          \"$payment_gateway\" : \"$braintree\",\n" +
+            "          \"$card_bin\"        : \"542486\",\n" +
+            "          \"$card_last4\"      : \"4444\"\n" +
+            "      }\n" +
+            "  ],\n" +
+            "  \"$shipping_address\"  : {\n" +
+            "      \"$name\"          : \"Bill Jones\",\n" +
+            "      \"$phone\"         : \"1-415-555-6041\",\n" +
+            "      \"$address_1\"     : \"2100 Main Street\",\n" +
+            "      \"$address_2\"     : \"Apt 3B\",\n" +
+            "      \"$city\"          : \"New London\",\n" +
+            "      \"$region\"        : \"New Hampshire\",\n" +
+            "      \"$country\"       : \"US\",\n" +
+            "      \"$zipcode\"       : \"03257\"\n" +
+            "  },\n" +
+            "  \"$expedited_shipping\" : true,\n" +
+            "  \"$shipping_method\"    : \"$physical\",\n" +
+            "  \"$bookings\": [\n" +
+            "    {\n" +
+            "      \"$booking_type\": \"$flight\",\n" +
+            "      \"$title\": \"SFO - LAS, 2 Adults\",\n" +
+            "      \"$start_time\": 12038412903,\n" +
+            "      \"$end_time\": 12048412903,\n" +
+            "      \"$guests\": [\n" +
+            "        {\n" +
+            "          \"$name\": \"John Doe\",\n" +
+            "          \"$birth_date\": \"1985-01-19\",\n" +
+            "          \"$loyalty_program\": \"skymiles\",\n" +
+            "          \"$loyalty_program_id\": \"PSOV34DF\",\n" +
+            "          \"$phone\": \"1-415-555-6040\",\n" +
+            "          \"$email\": \"jdeo@domain.com\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"$name\": \"Jane Doe\"\n" +
+            "        }\n" +
+            "      ],\n" +
+            "      \"$segments\": [\n" +
+            "        {\n" +
+            "          \"$departure_address\":\n" +
+            "          {\n" +
+            "            \"$name\": \"Bill Jones\",\n" +
+            "            \"$phone\": \"1-415-555-6040\",\n" +
+            "            \"$address_1\": \"2100 Main Street\",\n" +
+            "            \"$address_2\": \"Apt 3B\",\n" +
+            "            \"$city\": \"New London\",\n" +
+            "            \"$region\": \"New Hampshire\",\n" +
+            "            \"$country\": \"US\",\n" +
+            "            \"$zipcode\": \"03257\"\n" +
+            "          },\n" +
+            "          \"$arrival_address\":\n" +
+            "          {\n" +
+            "            \"$name\": \"Bill Jones\",\n" +
+            "            \"$phone\": \"1-415-555-6041\",\n" +
+            "            \"$address_1\": \"2100 Main Street\",\n" +
+            "            \"$address_2\": \"Apt 3B\",\n" +
+            "            \"$city\": \"New London\",\n" +
+            "            \"$region\": \"New Hampshire\",\n" +
+            "            \"$country\": \"US\",\n" +
+            "            \"$zipcode\": \"03257\"\n" +
+            "          },\n" +
+            "          \"$start_time\": 2190121220,\n" +
+            "          \"$end_time\": 2290122129,\n" +
+            "          \"$vessel_number\": \"LH454\",\n" +
+            "          \"$fare_class\": \"Premium Economy\",\n" +
+            "          \"$departure_airport_code\": \"SFO\",\n" +
+            "          \"$arrival_airport_code\": \"LAS\"\n" +
+            "        }\n" +
+            "      ],\n" +
+            "      \"$price\": 49900000,\n" +
+            "      \"$currency_code\": \"USD\",\n" +
+            "      \"$quantity\": 1\n" +
+            "    }\n" +
+            "  ],\n" +
+            "\n" +
+            "  \"$seller_user_id\"     : \"slinkys_emporium\",\n" +
+            "\n" +
+            "  \"$promotions\"         : [\n" +
+            "    {\n" +
+            "      \"$promotion_id\" : \"FirstTimeBuyer\",\n" +
+            "      \"$status\"       : \"$success\",\n" +
+            "      \"$description\"  : \"$5 off\",\n" +
+            "      \"$discount\"     : {\n" +
+            "        \"$amount\"                   : 5000000,\n" +
+            "        \"$currency_code\"            : \"USD\",\n" +
+            "        \"$minimum_purchase_amount\"  : 25000000\n" +
+            "      }\n" +
+            "    }\n" +
+            "  ],\n" +
+            "\n" +
+            "  \"digital_wallet\"      : \"apple_pay\",\n" +
+            "  \"coupon_code\"         : \"dollarMadness\",\n" +
+            "  \"shipping_choice\"     : \"FedEx Ground Courier\",\n" +
+            "  \"is_first_time_buyer\" : false\n" +
+            "}";
+
+        // Start a new mock server and enqueue a mock response.
+        MockWebServer server = new MockWebServer();
+        MockResponse response = new MockResponse();
+        response.setResponseCode(HTTP_OK);
+        response.setBody("{\n" +
+            "    \"status\" : 0,\n" +
+            "    \"error_message\" : \"OK\",\n" +
+            "    \"time\" : 1327604222,\n" +
+            "    \"request\" : \"" + TestUtils.unescapeJson(expectedRequestBody) + "\"\n" +
+            "}");
+        server.enqueue(response);
+        server.start();
+
+        // Create a new client and link it to the mock server.
+        SiftClient client = new SiftClient("YOUR_API_KEY", "YOUR_ACCOUNT_ID",
+            new OkHttpClient.Builder()
+                .addInterceptor(OkHttpUtils.urlRewritingInterceptor(server))
+                .build());
+
+        // Build the request body.
+        // Payment methods.
+        List<PaymentMethod> paymentMethodList = new ArrayList<>();
+        paymentMethodList.add(TestUtils.samplePaymentMethod1());
+
+        // Bookings
+        List<Booking> bookingList = new ArrayList<>();
+        bookingList.add(TestUtils.sampleBooking());
+
+        // Promotions.
+        List<Promotion> promotionList = new ArrayList<>();
+        promotionList.add(TestUtils.samplePromotion1());
+
+        // Build and execute the request against the mock server.
+        EventRequest request = client.buildRequest(
+            new CreateOrderFieldSet()
+                .setUserId("billy_jones_301")
+                .setSessionId("gigtleqddo84l8cm15qe4il")
+                .setOrderId("ORDER-28168441")
+                .setUserEmail("bill@gmail.com")
+                .setAmount(115940000L)
+                .setCurrencyCode("USD")
+                .setBillingAddress(TestUtils.sampleAddress2())
+                .setPaymentMethods(paymentMethodList)
+                .setShippingAddress(TestUtils.sampleAddress2())
+                .setExpeditedShipping(true)
+                .setShippingMethod("$physical")
+                .setBookings(bookingList)
+                .setSellerUserId("slinkys_emporium")
+                .setPromotions(promotionList)
+                .setCustomField("digital_wallet", "apple_pay")
+                .setCustomField("coupon_code", "dollarMadness")
+                .setCustomField("shipping_choice", "FedEx Ground Courier")
+                .setCustomField("is_first_time_buyer", false));
+
+        EventResponse siftResponse = request.send();
+
+        // Verify the request.
+        RecordedRequest request1 = server.takeRequest();
+        Assert.assertEquals("POST", request1.getMethod());
+        Assert.assertEquals("/v205/events", request1.getPath());
+        JSONAssert.assertEquals(expectedRequestBody, request.getFieldSet().toJson(), true);
+
+        // Verify the response.
+        Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
+        Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
+        JSONAssert.assertEquals(response.getBody().readUtf8(),
+            siftResponse.getBody().toJson(), true);
+
+        server.shutdown();
+    }
+}

--- a/src/test/java/com/siftscience/CreateOrderEventWithItemsTest.java
+++ b/src/test/java/com/siftscience/CreateOrderEventWithItemsTest.java
@@ -5,11 +5,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.siftscience.model.CreateOrderFieldSet;
 import com.siftscience.model.Item;
 import com.siftscience.model.PaymentMethod;
 import com.siftscience.model.Promotion;
-import com.siftscience.model.UpdateOrderFieldSet;
-import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -19,14 +18,15 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
-public class UpdateOrderEventTest {
+public class CreateOrderEventWithItemsTest {
 
     @Test
-    public void testUpdateOrderEvent() throws JSONException, IOException, InterruptedException {
+    public void testCreateOrderEvent() throws JSONException, IOException,
+            InterruptedException {
 
         // The expected JSON payload of the request.
         String expectedRequestBody = "{\n" +
-                "  \"$type\"             : \"$update_order\",\n" +
+                "  \"$type\"             : \"$create_order\",\n" +
                 "  \"$api_key\"          : \"YOUR_API_KEY\",\n" +
                 "  \"$user_id\"          : \"billy_jones_301\",\n" +
                 "\n" +
@@ -124,7 +124,7 @@ public class UpdateOrderEventTest {
                 "    \"error_message\" : \"OK\",\n" +
                 "    \"time\" : 1327604222,\n" +
                 "    \"request\" : \"" + TestUtils.unescapeJson(expectedRequestBody) + "\"\n" +
-                "}");
+        "}");
         server.enqueue(response);
         server.start();
 
@@ -148,10 +148,9 @@ public class UpdateOrderEventTest {
         List<Promotion> promotionList = new ArrayList<>();
         promotionList.add(TestUtils.samplePromotion1());
 
-
         // Build and execute the request against the mock server.
-        SiftRequest request = client.buildRequest(
-                new UpdateOrderFieldSet()
+        EventRequest request = client.buildRequest(
+                new CreateOrderFieldSet()
                         .setUserId("billy_jones_301")
                         .setSessionId("gigtleqddo84l8cm15qe4il")
                         .setOrderId("ORDER-28168441")
@@ -170,7 +169,7 @@ public class UpdateOrderEventTest {
                         .setCustomField("coupon_code", "dollarMadness")
                         .setCustomField("shipping_choice", "FedEx Ground Courier")
                         .setCustomField("is_first_time_buyer", false));
-        SiftResponse siftResponse = request.send();
+        EventResponse siftResponse = request.send();
 
         // Verify the request.
         RecordedRequest request1 = server.takeRequest();

--- a/src/test/java/com/siftscience/TestUtils.java
+++ b/src/test/java/com/siftscience/TestUtils.java
@@ -102,6 +102,52 @@ public class TestUtils {
                 .setQuantity(2L);
     }
 
+    static Booking sampleBooking() {
+        List<Guest> guests = new ArrayList<>();
+        guests.add(sampleGuest1());
+        guests.add(sampleGuest2());
+
+        List<Segment> segments = new ArrayList<>();
+        segments.add(sampleSegment());
+
+        return new Booking()
+            .setBookingType("$flight")
+            .setTitle("SFO - LAS, 2 Adults")
+            .setStartTime(12038412903L)
+            .setEndTime(12048412903L)
+            .setGuests(guests)
+            .setSegments(segments)
+            .setPrice(49900000L)
+            .setCurrencyCode("USD")
+            .setQuantity(1L);
+    }
+
+    static Guest sampleGuest1() {
+        return new Guest()
+                .setName("John Doe")
+                .setBirthDate("1985-01-19")
+                .setLoyaltyProgram("skymiles")
+                .setLoyaltyProgramId("PSOV34DF")
+                .setPhone("1-415-555-6040")
+                .setEmail("jdeo@domain.com");
+    }
+
+    static Guest sampleGuest2() {
+        return new Guest()
+            .setName("Jane Doe");
+    }
+
+    static Segment sampleSegment() {
+        return new Segment()
+            .setDepartureAddress(sampleAddress1())
+            .setArrivalAddress(sampleAddress2())
+            .setStartTime(2190121220L)
+            .setEndTime(2290122129L)
+            .setVesselNumber("LH454")
+            .setFareClass("Premium Economy")
+            .setDepartureAirportCode("SFO")
+            .setArrivalAirportCode("LAS");
+    }
     static Discount sampleDiscount1() {
         return new Discount()
                 .setAmount(5000000L)

--- a/src/test/java/com/siftscience/UpdateOrderEventWithBookingsTest.java
+++ b/src/test/java/com/siftscience/UpdateOrderEventWithBookingsTest.java
@@ -1,0 +1,215 @@
+package com.siftscience;
+
+import static java.net.HttpURLConnection.HTTP_OK;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.siftscience.model.Booking;
+import com.siftscience.model.PaymentMethod;
+import com.siftscience.model.Promotion;
+import com.siftscience.model.UpdateOrderFieldSet;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.json.JSONException;
+import org.junit.Assert;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+public class UpdateOrderEventWithBookingsTest {
+
+    @Test
+    public void testUpdateOrderEvent() throws JSONException, IOException, InterruptedException {
+
+        // The expected JSON payload of the request.
+        String expectedRequestBody = "{\n" +
+            "  \"$type\"             : \"$update_order\",\n" +
+            "  \"$api_key\"          : \"YOUR_API_KEY\",\n" +
+            "  \"$user_id\"          : \"billy_jones_301\",\n" +
+            "\n" +
+            "  \"$session_id\"       : \"gigtleqddo84l8cm15qe4il\",\n" +
+            "  \"$order_id\"         : \"ORDER-28168441\",\n" +
+            "  \"$user_email\"       : \"bill@gmail.com\",\n" +
+            "  \"$amount\"           : 115940000,\n" +
+            "  \"$currency_code\"    : \"USD\",\n" +
+            "  \"$billing_address\"  : {\n" +
+            "      \"$name\"         : \"Bill Jones\",\n" +
+            "      \"$phone\"        : \"1-415-555-6041\",\n" +
+            "      \"$address_1\"    : \"2100 Main Street\",\n" +
+            "      \"$address_2\"    : \"Apt 3B\",\n" +
+            "      \"$city\"         : \"New London\",\n" +
+            "      \"$region\"       : \"New Hampshire\",\n" +
+            "      \"$country\"      : \"US\",\n" +
+            "      \"$zipcode\"      : \"03257\"\n" +
+            "  },\n" +
+            "  \"$payment_methods\"  : [\n" +
+            "      {\n" +
+            "          \"$payment_type\"    : \"$credit_card\",\n" +
+            "          \"$payment_gateway\" : \"$braintree\",\n" +
+            "          \"$card_bin\"        : \"542486\",\n" +
+            "          \"$card_last4\"      : \"4444\"\n" +
+            "      }\n" +
+            "  ],\n" +
+            "  \"$shipping_address\"  : {\n" +
+            "      \"$name\"          : \"Bill Jones\",\n" +
+            "      \"$phone\"         : \"1-415-555-6041\",\n" +
+            "      \"$address_1\"     : \"2100 Main Street\",\n" +
+            "      \"$address_2\"     : \"Apt 3B\",\n" +
+            "      \"$city\"          : \"New London\",\n" +
+            "      \"$region\"        : \"New Hampshire\",\n" +
+            "      \"$country\"       : \"US\",\n" +
+            "      \"$zipcode\"       : \"03257\"\n" +
+            "  },\n" +
+            "  \"$expedited_shipping\" : true,\n" +
+            "  \"$shipping_method\"    : \"$physical\",\n" +
+            "  \"$bookings\": [\n" +
+            "    {\n" +
+            "      \"$booking_type\": \"$flight\",\n" +
+            "      \"$title\": \"SFO - LAS, 2 Adults\",\n" +
+            "      \"$start_time\": 12038412903,\n" +
+            "      \"$end_time\": 12048412903,\n" +
+            "      \"$guests\": [\n" +
+            "        {\n" +
+            "          \"$name\": \"John Doe\",\n" +
+            "          \"$birth_date\": \"1985-01-19\",\n" +
+            "          \"$loyalty_program\": \"skymiles\",\n" +
+            "          \"$loyalty_program_id\": \"PSOV34DF\",\n" +
+            "          \"$phone\": \"1-415-555-6040\",\n" +
+            "          \"$email\": \"jdeo@domain.com\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"$name\": \"Jane Doe\"\n" +
+            "        }\n" +
+            "      ],\n" +
+            "      \"$segments\": [\n" +
+            "        {\n" +
+            "          \"$departure_address\":\n" +
+            "          {\n" +
+            "            \"$name\": \"Bill Jones\",\n" +
+            "            \"$phone\": \"1-415-555-6040\",\n" +
+            "            \"$address_1\": \"2100 Main Street\",\n" +
+            "            \"$address_2\": \"Apt 3B\",\n" +
+            "            \"$city\": \"New London\",\n" +
+            "            \"$region\": \"New Hampshire\",\n" +
+            "            \"$country\": \"US\",\n" +
+            "            \"$zipcode\": \"03257\"\n" +
+            "          },\n" +
+            "          \"$arrival_address\":\n" +
+            "          {\n" +
+            "            \"$name\": \"Bill Jones\",\n" +
+            "            \"$phone\": \"1-415-555-6041\",\n" +
+            "            \"$address_1\": \"2100 Main Street\",\n" +
+            "            \"$address_2\": \"Apt 3B\",\n" +
+            "            \"$city\": \"New London\",\n" +
+            "            \"$region\": \"New Hampshire\",\n" +
+            "            \"$country\": \"US\",\n" +
+            "            \"$zipcode\": \"03257\"\n" +
+            "          },\n" +
+            "          \"$start_time\": 2190121220,\n" +
+            "          \"$end_time\": 2290122129,\n" +
+            "          \"$vessel_number\": \"LH454\",\n" +
+            "          \"$fare_class\": \"Premium Economy\",\n" +
+            "          \"$departure_airport_code\": \"SFO\",\n" +
+            "          \"$arrival_airport_code\": \"LAS\"\n" +
+            "        }\n" +
+            "      ],\n" +
+            "      \"$price\": 49900000,\n" +
+            "      \"$currency_code\": \"USD\",\n" +
+            "      \"$quantity\": 1\n" +
+            "    }\n" +
+            "  ],\n" +
+            "\n" +
+            "  \"$seller_user_id\"     : \"slinkys_emporium\",\n" +
+            "\n" +
+            "  \"$promotions\"         : [\n" +
+            "    {\n" +
+            "      \"$promotion_id\" : \"FirstTimeBuyer\",\n" +
+            "      \"$status\"       : \"$success\",\n" +
+            "      \"$description\"  : \"$5 off\",\n" +
+            "      \"$discount\"     : {\n" +
+            "        \"$amount\"                   : 5000000,\n" +
+            "        \"$currency_code\"            : \"USD\",\n" +
+            "        \"$minimum_purchase_amount\"  : 25000000\n" +
+            "      }\n" +
+            "    }\n" +
+            "  ],\n" +
+            "\n" +
+            "  \"digital_wallet\"      : \"apple_pay\",\n" +
+            "  \"coupon_code\"         : \"dollarMadness\",\n" +
+            "  \"shipping_choice\"     : \"FedEx Ground Courier\",\n" +
+            "  \"is_first_time_buyer\" : false\n" +
+            "}";
+
+        // Start a new mock server and enqueue a mock response.
+        MockWebServer server = new MockWebServer();
+        MockResponse response = new MockResponse();
+        response.setResponseCode(HTTP_OK);
+        response.setBody("{\n" +
+            "    \"status\" : 0,\n" +
+            "    \"error_message\" : \"OK\",\n" +
+            "    \"time\" : 1327604222,\n" +
+            "    \"request\" : \"" + TestUtils.unescapeJson(expectedRequestBody) + "\"\n" +
+            "}");
+        server.enqueue(response);
+        server.start();
+
+        // Create a new client and link it to the mock server.
+        SiftClient client = new SiftClient("YOUR_API_KEY", "YOUR_ACCOUNT_ID",
+            new OkHttpClient.Builder()
+                .addInterceptor(OkHttpUtils.urlRewritingInterceptor(server))
+                .build());
+
+        // Build the request body.
+        // Payment methods.
+        List<PaymentMethod> paymentMethodList = new ArrayList<>();
+        paymentMethodList.add(TestUtils.samplePaymentMethod1());
+
+        // Bookings
+        List<Booking> bookingList = new ArrayList<>();
+        bookingList.add(TestUtils.sampleBooking());
+
+        // Promotions.
+        List<Promotion> promotionList = new ArrayList<>();
+        promotionList.add(TestUtils.samplePromotion1());
+
+        // Build and execute the request against the mock server.
+        SiftRequest request = client.buildRequest(
+            new UpdateOrderFieldSet()
+                .setUserId("billy_jones_301")
+                .setSessionId("gigtleqddo84l8cm15qe4il")
+                .setOrderId("ORDER-28168441")
+                .setUserEmail("bill@gmail.com")
+                .setAmount(115940000L)
+                .setCurrencyCode("USD")
+                .setBillingAddress(TestUtils.sampleAddress2())
+                .setPaymentMethods(paymentMethodList)
+                .setShippingAddress(TestUtils.sampleAddress2())
+                .setExpeditedShipping(true)
+                .setShippingMethod("$physical")
+                .setBookings(bookingList)
+                .setSellerUserId("slinkys_emporium")
+                .setPromotions(promotionList)
+                .setCustomField("digital_wallet", "apple_pay")
+                .setCustomField("coupon_code", "dollarMadness")
+                .setCustomField("shipping_choice", "FedEx Ground Courier")
+                .setCustomField("is_first_time_buyer", false));
+
+        SiftResponse siftResponse = request.send();
+
+        // Verify the request.
+        RecordedRequest request1 = server.takeRequest();
+        Assert.assertEquals("POST", request1.getMethod());
+        Assert.assertEquals("/v205/events", request1.getPath());
+        JSONAssert.assertEquals(expectedRequestBody, request.getFieldSet().toJson(), true);
+
+        // Verify the response.
+        Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
+        Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
+        JSONAssert.assertEquals(response.getBody().readUtf8(),
+            siftResponse.getBody().toJson(), true);
+
+        server.shutdown();
+    }
+}

--- a/src/test/java/com/siftscience/UpdateOrderEventWithItemsTest.java
+++ b/src/test/java/com/siftscience/UpdateOrderEventWithItemsTest.java
@@ -5,11 +5,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.siftscience.model.CreateOrderFieldSet;
 import com.siftscience.model.Item;
 import com.siftscience.model.PaymentMethod;
 import com.siftscience.model.Promotion;
-import okhttp3.HttpUrl;
+import com.siftscience.model.UpdateOrderFieldSet;
 import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -19,15 +18,14 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
-public class CreateOrderEventTest {
+public class UpdateOrderEventWithItemsTest {
 
     @Test
-    public void testCreateOrderEvent() throws JSONException, IOException,
-            InterruptedException {
+    public void testUpdateOrderEvent() throws JSONException, IOException, InterruptedException {
 
         // The expected JSON payload of the request.
         String expectedRequestBody = "{\n" +
-                "  \"$type\"             : \"$create_order\",\n" +
+                "  \"$type\"             : \"$update_order\",\n" +
                 "  \"$api_key\"          : \"YOUR_API_KEY\",\n" +
                 "  \"$user_id\"          : \"billy_jones_301\",\n" +
                 "\n" +
@@ -125,7 +123,7 @@ public class CreateOrderEventTest {
                 "    \"error_message\" : \"OK\",\n" +
                 "    \"time\" : 1327604222,\n" +
                 "    \"request\" : \"" + TestUtils.unescapeJson(expectedRequestBody) + "\"\n" +
-        "}");
+                "}");
         server.enqueue(response);
         server.start();
 
@@ -149,9 +147,10 @@ public class CreateOrderEventTest {
         List<Promotion> promotionList = new ArrayList<>();
         promotionList.add(TestUtils.samplePromotion1());
 
+
         // Build and execute the request against the mock server.
-        EventRequest request = client.buildRequest(
-                new CreateOrderFieldSet()
+        SiftRequest request = client.buildRequest(
+                new UpdateOrderFieldSet()
                         .setUserId("billy_jones_301")
                         .setSessionId("gigtleqddo84l8cm15qe4il")
                         .setOrderId("ORDER-28168441")
@@ -170,7 +169,7 @@ public class CreateOrderEventTest {
                         .setCustomField("coupon_code", "dollarMadness")
                         .setCustomField("shipping_choice", "FedEx Ground Courier")
                         .setCustomField("is_first_time_buyer", false));
-        EventResponse siftResponse = request.send();
+        SiftResponse siftResponse = request.send();
 
         // Verify the request.
         RecordedRequest request1 = server.takeRequest();


### PR DESCRIPTION
**Purpose:**
Capture travel and ticketing specific data by providing additional fields in the API. Here is the spec.

Technical overview:

- Add support for the new ```booking``` fields in ```$create_order``` and ```$update_order``` events


Testing Plan:
- Updated unit tests
- Send sample events using SiftClient to experiment environment and verify the changes using the experiment console.

Deployment:
will publish to Maven
Github release
(after the code changes for ```$bookings``` object are deployed)
