### PR TITLE
(for Rajesh) adding  $decline_category to  $transaction event

### DIFF
--- a/CHANGES.MD
+++ b/CHANGES.MD
@@ -1,3 +1,7 @@
+3.4.0 (2020-05-05)
+=================
+- Add support for `$decline_category` field to `$transaction` event
+
 3.3.0 (2020-02-19)
 =================
 - Add support for `$client_language` field to `$app` complex field

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Java 1.7 or later.
 <dependency>
     <groupId>com.siftscience</groupId>
     <artifactId>sift-java</artifactId>
-    <version>3.3.0</version>
+    <version>3.4.0</version>
 </dependency>
 ```
 ### Gradle
 ```
 dependencies {
-    compile 'com.siftscience:sift-java:3.3.0'
+    compile 'com.siftscience:sift-java:3.4.0'
 }
 ```
 ### Other

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'signing'
 apply plugin: 'java-library-distribution'
 
 group = 'com.siftscience'
-version = '3.3.0'
+version = '3.4.0'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/siftscience/model/TransactionFieldSet.java
+++ b/src/main/java/com/siftscience/model/TransactionFieldSet.java
@@ -17,6 +17,7 @@ public class TransactionFieldSet extends BaseAppBrowserSiteBrandFieldSet<Transac
     @Expose @SerializedName("$seller_user_id") private String sellerUserId;
     @Expose @SerializedName("$transfer_recipient_user_id") private String transferRecipientUserId;
     @Expose @SerializedName("$ordered_from") private OrderedFrom orderedFrom;
+    @Expose @SerializedName("$decline_category") private String declineCategory;
 
     @Override
     public String getEventType() {
@@ -141,6 +142,15 @@ public class TransactionFieldSet extends BaseAppBrowserSiteBrandFieldSet<Transac
 
     public TransactionFieldSet setOrderedFrom(OrderedFrom orderedFrom) {
         this.orderedFrom = orderedFrom;
+        return this;
+    }
+
+    public String getDeclineCategory() {
+        return declineCategory;
+    }
+
+    public TransactionFieldSet setDeclineCategory(String declineCategory) {
+        this.declineCategory = declineCategory;
         return this;
     }
 }

--- a/src/test/java/com/siftscience/TransactionEventTest.java
+++ b/src/test/java/com/siftscience/TransactionEventTest.java
@@ -23,9 +23,10 @@ public class TransactionEventTest {
                 "\n" +
                 "  \"$user_email\"       : \"bill@gmail.com\",\n" +
                 "  \"$transaction_type\" : \"$sale\",\n" +
-                "  \"$transaction_status\" : \"$success\",\n" +
+                "  \"$transaction_status\" : \"$failure\",\n" +
                 "  \"$order_id\"         : \"ORDER-123124124\",\n" +
                 "  \"$transaction_id\"   : \"719637215\",\n" +
+                "  \"$decline_category\" : \"$lost\",\n" +
                 "  \"$site_country\": \"US\",\n" +
                 "  \"$site_domain\": \"sift.com\",\n" +
                 "  \"$brand_name\": \"sift\",\n" +
@@ -105,7 +106,8 @@ public class TransactionEventTest {
                 .setCurrencyCode("USD")
                 .setUserEmail("bill@gmail.com")
                 .setTransactionType("$sale")
-                .setTransactionStatus("$success")
+                .setTransactionStatus("$failure")
+                .setDeclineCategory("$lost")
                 .setSiteCountry("US")
                 .setSiteDomain("sift.com")
                 .setBrandName("sift")


### PR DESCRIPTION
Purpose

- Add additional $decline_category field to $transaction event to make it possible to pass decline reason on transaction level.

Technical Overview

- Adding $decline_category field to TransactionFieldSet

Testing Plan

- Run unit tests
- Send sample events using SiftClient to the internal experiment environment and verify the changes using the internal experiment console.

Deployment

- Publish to Maven Central
- Create a GitHub release