### PR TITLE
 adding support for sepa complex field in payment_method

### DIFF
--- a/src/main/java/com/siftscience/model/PaymentMethod.java
+++ b/src/main/java/com/siftscience/model/PaymentMethod.java
@@ -27,6 +27,7 @@ public class PaymentMethod {
     @Expose @SerializedName("$stripe_funding") private String stripeFunding;
     @Expose @SerializedName("$stripe_brand") private String stripeBrand;
     @Expose @SerializedName("$ach") private Ach ach;
+    @Expose @SerializedName("$sepa") private Sepa sepa;
 
     public String getPaymentType() {
         return paymentType;
@@ -223,6 +224,15 @@ public class PaymentMethod {
 
     public PaymentMethod setAch(Ach ach) {
         this.ach = ach;
+        return this;
+    }
+
+    public Sepa getSepa() {
+        return sepa;
+    }
+
+    public PaymentMethod setSepa(Sepa sepa) {
+        this.sepa = sepa;
         return this;
     }
 }

--- a/src/main/java/com/siftscience/model/Sepa.java
+++ b/src/main/java/com/siftscience/model/Sepa.java
@@ -1,0 +1,58 @@
+package com.siftscience.model;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+public class Sepa {
+
+    @Expose @SerializedName("$sepa_type") private String sepaType;
+    @Expose @SerializedName("$account_holder_name") private String accountHolderName;
+    @Expose @SerializedName("$shortened_iban") private String shortenedIban;
+    @Expose @SerializedName("$bic") private String bic;
+    @Expose @SerializedName("$mandate_id") private String mandateId;
+
+    public String getSepaType() {
+        return sepaType;
+    }
+
+    public Sepa setSepaType(String sepaType) {
+        this.sepaType = sepaType;
+        return this;
+    }
+
+    public String getAccountHolderName() {
+        return accountHolderName;
+    }
+
+    public Sepa setAccountHolderName(String accountHolderName) {
+        this.accountHolderName = accountHolderName;
+        return this;
+    }
+
+    public String getShortenedIban() {
+        return shortenedIban;
+    }
+
+    public Sepa setShortenedIban(String iban) {
+        this.shortenedIban = iban;
+        return this;
+    }
+
+    public String getBic() {
+        return bic;
+    }
+
+    public Sepa setBic(String bic) {
+        this.bic = bic;
+        return this;
+    }
+
+    public String getMandateId() {
+        return mandateId;
+    }
+
+    public Sepa setMandateId(String mandateId) {
+        this.mandateId = mandateId;
+        return this;
+    }
+}

--- a/src/test/java/com/siftscience/TestUtils.java
+++ b/src/test/java/com/siftscience/TestUtils.java
@@ -11,6 +11,7 @@ import com.siftscience.model.OrderedFrom;
 import com.siftscience.model.PaymentMethod;
 import com.siftscience.model.Promotion;
 import com.siftscience.model.Segment;
+import com.siftscience.model.Sepa;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -69,12 +70,17 @@ public class TestUtils {
 
     static PaymentMethod samplePaymentMethod3() {
         return new PaymentMethod()
-                .setAch(new Ach()
-                        .setAchType("$credit")
-                        .setRoutingNumber("072403005")
-                        .setAccountNumber("12345")
-                        .setAccountHolderName("Jane Doe")
-        );
+            .setAch(new Ach()
+                .setAchType("$credit")
+                .setRoutingNumber("072403005")
+                .setAccountNumber("12345")
+                .setAccountHolderName("Jane Doe")
+            );
+    }
+
+    static PaymentMethod samplePaymentMethodWithSepa() {
+        return new PaymentMethod()
+                .setSepa(sampleSepa());
     }
 
     static List<String> sampleTags1() {
@@ -232,5 +238,14 @@ public class TestUtils {
         categories.add("Apartments");
         categories.add("2 Bedrooms");
         return categories;
+    }
+
+    static Sepa sampleSepa() {
+        return new Sepa()
+                .setSepaType("$instant_credit")
+                .setAccountHolderName("John Doe")
+                .setShortenedIban("FR76300060")
+                .setBic("testtest1")
+                .setMandateId("mandate_id");
     }
 }


### PR DESCRIPTION
**Purpose**
- Add `sepa` complex field to support SEPA payment method which can be used for various fintech purposes in the future like feature extraction, reporting, workflow management, etc.

**Technical Overview**
- Add support  for `$sepa` complex field which contains `$sepa_type`, `$account_holder_name`, `$shortened_iban`, `$bic`, and `$mandate_id` fields which would be part of `$payment_method` field.

**Testing Plan**
- [x] Updated unit tests

**Deployment**
(Once all the fintech-related changes are merged)
- Publish to Maven Central
- Create a GitHub release

Note - I will update the changelog during the last PR as it would cause conflicts now.