### PR TITLE
update okhttp

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'signing'
 apply plugin: 'java-library-distribution'
 
 group = 'com.siftscience'
-version = '3.4.3'
+version = '3.4.4'
 
 repositories {
     mavenCentral()
@@ -26,7 +26,7 @@ dependencies {
     testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.4.2'
     testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: '1.3'
     compile 'com.google.code.gson:gson:2.7'
-    compile 'com.squareup.okhttp3:okhttp:3.4.2'
+    compile 'com.squareup.okhttp3:okhttp:4.9.2'
     compile 'com.squareup.okio:okio:1.9.0'
 }
 


### PR DESCRIPTION
A proposal to update okhttp lib;
The [changelog](https://github.com/square/okhttp/blob/master/CHANGELOG.md) contains various fixes expecially to downgrade http/2 stream after a timeout.

okttp instructions [how to migrate to v4](https://square.github.io/okhttp/upgrading_to_okhttp_4/) shows that retro-compatibility has been largely supported.