### PR TITLE
Adding support for $merchant_profile complex field to $create_account, $update_account, and $chargeback events

### DIFF
--- a/CHANGES.MD
+++ b/CHANGES.MD
@@ -1,3 +1,7 @@
+3.4.4 (2022-03-24)
+=================
+- Add support for `$merchant_profile` complex field to `$create_account`, `$update_account`, and `$chargeback` events
+
 3.4.3 (2021-10-12)
 =================
 - Add support for `$shortened_iban_first6`, `$shortened_iban_last4`, and `$sepa_direct_debit_mandate` to `$payment_method` complex field and `$transaction` event

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Java 1.7 or later.
 <dependency>
     <groupId>com.siftscience</groupId>
     <artifactId>sift-java</artifactId>
-    <version>3.4.3</version>
+    <version>3.4.4</version>
 </dependency>
 ```
 ### Gradle
 ```
 dependencies {
-    compile 'com.siftscience:sift-java:3.4.3'
+    compile 'com.siftscience:sift-java:3.4.4'
 }
 ```
 ### Other

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'signing'
 apply plugin: 'java-library-distribution'
 
 group = 'com.siftscience'
-version = '3.4.3'
+version = '3.4.4'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/siftscience/model/BaseAccountFieldSet.java
+++ b/src/main/java/com/siftscience/model/BaseAccountFieldSet.java
@@ -15,6 +15,7 @@ public abstract class BaseAccountFieldSet<T extends BaseAccountFieldSet<T>>
     @Expose @SerializedName("$billing_address") private Address billingAddress;
     @Expose @SerializedName("$shipping_address") private Address shippingAddress;
     @Expose @SerializedName("$social_sign_on_type") private String socialSignOnType;
+    @Expose @SerializedName("$merchant_profile") private MerchantProfile merchantProfile;
 
     public String getUserEmail() {
         return userEmail;
@@ -85,6 +86,15 @@ public abstract class BaseAccountFieldSet<T extends BaseAccountFieldSet<T>>
 
     public T setSocialSignOnType(String socialSignOnType) {
         this.socialSignOnType = socialSignOnType;
+        return (T) this;
+    }
+
+    public MerchantProfile getMerchantProfile() {
+        return merchantProfile;
+    }
+
+    public T setMerchantProfile(MerchantProfile merchantProfile) {
+        this.merchantProfile = merchantProfile;
         return (T) this;
     }
 }

--- a/src/main/java/com/siftscience/model/ChargebackFieldSet.java
+++ b/src/main/java/com/siftscience/model/ChargebackFieldSet.java
@@ -12,6 +12,7 @@ public class ChargebackFieldSet extends EventsApiRequestFieldSet<ChargebackField
     @Expose @SerializedName("$transaction_id") private String transactionId;
     @Expose @SerializedName("$chargeback_state") private String chargebackState;
     @Expose @SerializedName("$chargeback_reason") private String chargebackReason;
+    @Expose @SerializedName("$merchant_profile") private MerchantProfile merchantProfile;
 
     @Override
     public String getEventType() {
@@ -51,6 +52,15 @@ public class ChargebackFieldSet extends EventsApiRequestFieldSet<ChargebackField
 
     public ChargebackFieldSet setChargebackReason(String chargebackReason) {
         this.chargebackReason = chargebackReason;
+        return this;
+    }
+
+    public MerchantProfile getMerchantProfile() {
+        return merchantProfile;
+    }
+
+    public ChargebackFieldSet setMerchantProfile(MerchantProfile merchantProfile) {
+        this.merchantProfile = merchantProfile;
         return this;
     }
 }

--- a/src/test/java/com/siftscience/ChargebackEventTest.java
+++ b/src/test/java/com/siftscience/ChargebackEventTest.java
@@ -22,8 +22,23 @@ public class ChargebackEventTest {
                 "  \"$transaction_id\"    : \"719637215\",\n" +
                 "\n" +
                 "  \"$chargeback_state\"  : \"$lost\",\n" +
-                "  \"$chargeback_reason\" : \"$duplicate\"\n" +
-                "}";
+                "  \"$chargeback_reason\" : \"$duplicate\",\n" +
+                "  \"$merchant_profile\" : {\n" +
+                "    \"$merchant_id\"            : \"12345\",\n" +
+                "    \"$merchant_category_code\" : \"9876\",\n" +
+                "    \"$merchant_name\"          : \"ABC Merchant\",\n" +
+                "    \"$merchant_address\" : {\n" +
+                "      \"$address_1\" : \"2100 Main Street\",\n" +
+                "      \"$address_2\" : \"Apt 3B\",\n" +
+                "      \"$city\"      : \"New London\",\n" +
+                "      \"$country\"   : \"US\",\n" +
+                "      \"$name\"      : \"Bill Jones\",\n" +
+                "      \"$phone\"     : \"1-415-555-6040\",\n" +
+                "      \"$region\"    : \"New Hampshire\",\n" +
+                "      \"$zipcode\"   : \"03257\"\n" +
+                "    }\n" +
+                "  }\n" +
+                "}\n";
 
         // Start a new mock server and enqueue a mock response.
         MockWebServer server = new MockWebServer();
@@ -50,7 +65,8 @@ public class ChargebackEventTest {
                 .setOrderId("ORDER-123124124")
                 .setTransactionId("719637215")
                 .setChargebackState("$lost")
-                .setChargebackReason("$duplicate"));
+                .setChargebackReason("$duplicate")
+                .setMerchantProfile(TestUtils.sampleMerchantProfile()));
 
         EventResponse siftResponse = request.send();
 

--- a/src/test/java/com/siftscience/CreateAccountEventTest.java
+++ b/src/test/java/com/siftscience/CreateAccountEventTest.java
@@ -77,8 +77,23 @@ public class CreateAccountEventTest {
                 "  \"referral_code\"           : \"MIKEFRIENDS\",\n" +
                 "  \"email_confirmed_status\"  : \"$pending\",\n" +
                 "  \"phone_confirmed_status\"  : \"$pending\",\n" +
-                "  \"$account_types\" : [\"merchant\", \"premium\"]\n" +
-                "}";
+                "  \"$account_types\" : [\"merchant\", \"premium\"],\n" +
+                "  \"$merchant_profile\" : {\n" +
+                "    \"$merchant_id\"            : \"12345\",\n" +
+                "    \"$merchant_category_code\" : \"9876\",\n" +
+                "    \"$merchant_name\"          : \"ABC Merchant\",\n" +
+                "    \"$merchant_address\" : {\n" +
+                "      \"$address_1\" : \"2100 Main Street\",\n" +
+                "      \"$address_2\" : \"Apt 3B\",\n" +
+                "      \"$city\"      : \"New London\",\n" +
+                "      \"$country\"   : \"US\",\n" +
+                "      \"$name\"      : \"Bill Jones\",\n" +
+                "      \"$phone\"     : \"1-415-555-6040\",\n" +
+                "      \"$region\"    : \"New Hampshire\",\n" +
+                "      \"$zipcode\"   : \"03257\"\n" +
+                "    }\n" +
+                "  }\n" +
+                "}\n";
 
         // Start a new mock server and enqueue a mock response.
         MockWebServer server = new MockWebServer();
@@ -127,7 +142,8 @@ public class CreateAccountEventTest {
                         .setCustomField("referral_code", "MIKEFRIENDS")
                         .setCustomField("email_confirmed_status", "$pending")
                         .setCustomField("phone_confirmed_status", "$pending")
-                        .setAccountTypes(Arrays.asList("merchant", "premium")));
+                        .setAccountTypes(Arrays.asList("merchant", "premium"))
+                        .setMerchantProfile(TestUtils.sampleMerchantProfile()));
 
         SiftResponse siftResponse = request.send();
 

--- a/src/test/java/com/siftscience/UpdateAccountEventTest.java
+++ b/src/test/java/com/siftscience/UpdateAccountEventTest.java
@@ -58,8 +58,23 @@ public class UpdateAccountEventTest {
                 "  \"$social_sign_on_type\"   : \"$twitter\",\n" +
                 "  \"email_confirmed_status\"  : \"$success\",\n" +
                 "  \"phone_confirmed_status\"  : \"$success\",\n" +
-                "  \"$account_types\" : [\"merchant\", \"premium\"]\n" +
-                "}";
+                "  \"$account_types\" : [\"merchant\", \"premium\"],\n" +
+                "  \"$merchant_profile\" : {\n" +
+                "    \"$merchant_id\"            : \"12345\",\n" +
+                "    \"$merchant_category_code\" : \"9876\",\n" +
+                "    \"$merchant_name\"          : \"ABC Merchant\",\n" +
+                "    \"$merchant_address\" : {\n" +
+                "      \"$address_1\" : \"2100 Main Street\",\n" +
+                "      \"$address_2\" : \"Apt 3B\",\n" +
+                "      \"$city\"      : \"New London\",\n" +
+                "      \"$country\"   : \"US\",\n" +
+                "      \"$name\"      : \"Bill Jones\",\n" +
+                "      \"$phone\"     : \"1-415-555-6040\",\n" +
+                "      \"$region\"    : \"New Hampshire\",\n" +
+                "      \"$zipcode\"   : \"03257\"\n" +
+                "    }\n" +
+                "  }\n" +
+                "}\n";
 
         // Start a new mock server and enqueue a mock response.
         MockWebServer server = new MockWebServer();
@@ -99,7 +114,9 @@ public class UpdateAccountEventTest {
                         .setSocialSignOnType("$twitter")
                         .setCustomField("email_confirmed_status", "$success")
                         .setCustomField("phone_confirmed_status", "$success")
-                        .setAccountTypes(Arrays.asList("merchant", "premium")));
+                        .setAccountTypes(Arrays.asList("merchant", "premium"))
+                        .setMerchantProfile(TestUtils.sampleMerchantProfile()));
+
 
         SiftResponse siftResponse = request.send();
 


### PR DESCRIPTION
**Purpose**
- Adding support for $merchant_profile complex field to $create_account, $update_account, and $chargeback events

**Technical Overview**
- Adding support for $merchant_profile complex field to $create_account, $update_account, and $chargeback events
- Updated `BaseAccountFieldSet.java` and `ChargebackFieldSet.java` with $merchant_profile field

**Testing Plan**
- [x] Updated unit tests

**Deployment**
(Once all the fintech-related changes are merged)
- Publish to Maven Central
- Create a GitHub release
