### PR TITLE
updating the gradle version to 6.8.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,8 @@ dependencies {
     compile 'com.squareup.okio:okio:1.9.0'
 }
 
-task wrapper(type: Wrapper) {
-    gradleVersion = '3.1'
+wrapper {
+    gradleVersion = '6.8.3'
 }
 
 buildscript {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip


### PR DESCRIPTION
Updating the gradle version to 6.8.3 as running `./gradlew distZip` is not compatible with Java 11