### PR TITLE
API-6578: Added support for $name and $phone is custom events

### DIFF
--- a/CHANGES.MD
+++ b/CHANGES.MD
@@ -1,3 +1,7 @@
+3.5.1 (2022-07-05)
+=================
+- Added support for $name and $phone is custom events
+
 3.5.0 (2022-06-21)
 =================
 - Adding support for return_route_info query parameter for [Sync request](https://sift.com/developers/docs/curl/workflows-api/running-workflows/synchronous)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Java 1.7 or later.
 <dependency>
     <groupId>com.siftscience</groupId>
     <artifactId>sift-java</artifactId>
-    <version>3.5.0</version>
+    <version>3.5.1</version>
 </dependency>
 ```
 ### Gradle

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'signing'
 apply plugin: 'java-library-distribution'
 
 group = 'com.siftscience'
-version = '3.5.0'
+version = '3.5.1'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/siftscience/model/CustomEventFieldSet.java
+++ b/src/main/java/com/siftscience/model/CustomEventFieldSet.java
@@ -10,6 +10,8 @@ public class CustomEventFieldSet extends BaseAppBrowserSiteBrandFieldSet<CustomE
 
     @Expose @SerializedName(EVENT_TYPE) private String eventType;
     @Expose @SerializedName("$user_email") private String userEmail;
+    @Expose @SerializedName("$name") private String name;
+    @Expose @SerializedName("$phone") private String phone;
 
     @Override
     public String getEventType() {
@@ -27,6 +29,24 @@ public class CustomEventFieldSet extends BaseAppBrowserSiteBrandFieldSet<CustomE
 
     public CustomEventFieldSet setUserEmail(String userEmail) {
         this.userEmail = userEmail;
+        return this;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public CustomEventFieldSet setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public CustomEventFieldSet setPhone(String phone) {
+        this.phone = phone;
         return this;
     }
 }

--- a/src/test/java/com/siftscience/CustomEventTest.java
+++ b/src/test/java/com/siftscience/CustomEventTest.java
@@ -23,6 +23,8 @@ public class CustomEventTest {
                 "  \"$site_domain\": \"sift.com\",\n" +
                 "  \"$brand_name\": \"sift\",\n" +
                 "  \"$user_email\": \"sift@sift.com\",\n" +
+                "  \"$name\": \"Sift\",\n" +
+                "  \"phone\": \"(415) 882-7709\",\n" +
                 "  \"call_duration\"      : 4428\n" +
                 "}";
 
@@ -53,6 +55,8 @@ public class CustomEventTest {
                 .setSiteDomain("sift.com")
                 .setBrandName("sift")
                 .setUserEmail("sift@sift.com")
+                .setName("Sift")
+                .setPhone("(415) 882-7709")
                 .setCustomField("recipient_user_id", "marylee819")
                 .setCustomField("call_duration", 4428));
 


### PR DESCRIPTION
# Purpose 
Update Java client library to send $name and $phone as reserved fields on custom events

# Testing plan 
Updated unit test

# Severity 
3