### PR TITLE
[PAY-3228] - Add support for Crypto API and ACH return fields

### DIFF
--- a/CHANGES.MD
+++ b/CHANGES.MD
@@ -1,3 +1,7 @@
+3.8.0 (2022-12-09)
+=================
+- Add support for `$ach_return_code` field to `$chargeback` event
+
 3.7.0 (2022-11-09)
 =================
 - added support for merchant management api

--- a/CHANGES.MD
+++ b/CHANGES.MD
@@ -1,6 +1,10 @@
 3.8.0 (2022-12-09)
 =================
 - Add support for `$ach_return_code` field to `$chargeback` event
+- Add support for `$wallet_address` and `$wallet_type` fields to `$payment_method` complex field
+- Add support for `$digital_order` complex field  
+- Add support for `$digital_orders` field to `$transaction`, `$create_order`, and `$update_order` events
+- Add support for `$receiver_wallet_address` and `$receiver_external_address` fields to `$transaction` event
 
 3.7.0 (2022-11-09)
 =================

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Java 1.7 or later.
 <dependency>
     <groupId>com.siftscience</groupId>
     <artifactId>sift-java</artifactId>
-    <version>3.7.0</version>
+    <version>3.8.0</version>
 </dependency>
 ```
 ### Gradle
 ```
 dependencies {
-    compile 'com.siftscience:sift-java:3.7.0'
+    compile 'com.siftscience:sift-java:3.8.0'
 }
 ```
 ### Other

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'signing'
 apply plugin: 'java-library-distribution'
 
 group = 'com.siftscience'
-version = '3.7.0'
+version = '3.8.0'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/siftscience/model/BaseOrderFieldSet.java
+++ b/src/main/java/com/siftscience/model/BaseOrderFieldSet.java
@@ -23,6 +23,7 @@ public abstract class BaseOrderFieldSet<T extends BaseOrderFieldSet<T>>
     @Expose @SerializedName("$ordered_from") private OrderedFrom orderedFrom;
     @Expose @SerializedName("$merchant_profile") private MerchantProfile merchantProfile;
     @Expose @SerializedName(VERIFICATION_PHONE_NUMBER) private String verificationPhoneNumber;
+    @Expose @SerializedName("$digital_orders") private List<DigitalOrder> digitalOrders;
 
     public String getOrderId() {
         return orderId;
@@ -169,6 +170,15 @@ public abstract class BaseOrderFieldSet<T extends BaseOrderFieldSet<T>>
 
     public T setVerificationPhoneNumber(String verificationPhoneNumber) {
         this.verificationPhoneNumber = verificationPhoneNumber;
+        return (T) this;
+    }
+
+    public List<DigitalOrder> getDigitalOrders() {
+        return digitalOrders;
+    }
+
+    public T setDigitalOrders(List<DigitalOrder> digitalOrders) {
+        this.digitalOrders = digitalOrders;
         return (T) this;
     }
 }

--- a/src/main/java/com/siftscience/model/ChargebackFieldSet.java
+++ b/src/main/java/com/siftscience/model/ChargebackFieldSet.java
@@ -13,6 +13,7 @@ public class ChargebackFieldSet extends EventsApiRequestFieldSet<ChargebackField
     @Expose @SerializedName("$chargeback_state") private String chargebackState;
     @Expose @SerializedName("$chargeback_reason") private String chargebackReason;
     @Expose @SerializedName("$merchant_profile") private MerchantProfile merchantProfile;
+    @Expose @SerializedName("$ach_return_code") private String achReturnCode;
 
     @Override
     public String getEventType() {
@@ -61,6 +62,15 @@ public class ChargebackFieldSet extends EventsApiRequestFieldSet<ChargebackField
 
     public ChargebackFieldSet setMerchantProfile(MerchantProfile merchantProfile) {
         this.merchantProfile = merchantProfile;
+        return this;
+    }
+
+    public String getAchReturnCode() {
+        return achReturnCode;
+    }
+
+    public ChargebackFieldSet setAchReturnCode(String achReturnCode) {
+        this.achReturnCode = achReturnCode;
         return this;
     }
 }

--- a/src/main/java/com/siftscience/model/DigitalOrder.java
+++ b/src/main/java/com/siftscience/model/DigitalOrder.java
@@ -1,0 +1,57 @@
+package com.siftscience.model;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+public class DigitalOrder {
+    @Expose @SerializedName("$digital_asset") private String digitalAsset;
+    @Expose @SerializedName("$pair") private String pair;
+    @Expose @SerializedName("$asset_type") private String assetType;
+    @Expose @SerializedName("$order_type") private String orderType;
+    @Expose @SerializedName("$volume") private String volume;
+
+    public String getDigitalAsset() {
+        return digitalAsset;
+    }
+
+    public DigitalOrder setDigitalAsset(String digitalAsset) {
+        this.digitalAsset = digitalAsset;
+        return this;
+    }
+
+    public String getPair() {
+        return pair;
+    }
+
+    public DigitalOrder setPair(String pair) {
+        this.pair = pair;
+        return this;
+    }
+
+    public String getAssetType() {
+        return assetType;
+    }
+
+    public DigitalOrder setAssetType(String assetType) {
+        this.assetType = assetType;
+        return this;
+    }
+
+    public String getOrderType() {
+        return orderType;
+    }
+
+    public DigitalOrder setOrderType(String orderType) {
+        this.orderType = orderType;
+        return this;
+    }
+
+    public String getVolume() {
+        return volume;
+    }
+
+    public DigitalOrder setVolume(String volume) {
+        this.volume = volume;
+        return this;
+    }
+}

--- a/src/main/java/com/siftscience/model/PaymentMethod.java
+++ b/src/main/java/com/siftscience/model/PaymentMethod.java
@@ -33,6 +33,8 @@ public class PaymentMethod {
     @Expose @SerializedName("$shortened_iban_first6") private String shortenedIbanFirst6;
     @Expose @SerializedName("$shortened_iban_last4") private String shortenedIbanLast4;
     @Expose @SerializedName("$sepa_direct_debit_mandate") private Boolean sepaDirectDebitMandate;
+    @Expose @SerializedName("$wallet_address") private String walletAddress;
+    @Expose @SerializedName("$wallet_type") private String walletType;
 
     public String getPaymentType() {
         return paymentType;
@@ -283,6 +285,24 @@ public class PaymentMethod {
 
     public PaymentMethod setSepaDirectDebitMandate(Boolean sepaDirectDebitMandate) {
         this.sepaDirectDebitMandate = sepaDirectDebitMandate;
+        return this;
+    }
+
+    public String getWalletAddress() {
+        return walletAddress;
+    }
+
+    public PaymentMethod setWalletAddress(String walletAddress) {
+        this.walletAddress = walletAddress;
+        return this;
+    }
+
+    public String getWalletType() {
+        return walletType;
+    }
+
+    public PaymentMethod setWalletType(String walletType) {
+        this.walletType = walletType;
         return this;
     }
 }

--- a/src/main/java/com/siftscience/model/TransactionFieldSet.java
+++ b/src/main/java/com/siftscience/model/TransactionFieldSet.java
@@ -1,5 +1,7 @@
 package com.siftscience.model;
 
+import java.util.List;
+
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
@@ -26,6 +28,9 @@ public class TransactionFieldSet extends BaseAppBrowserSiteBrandFieldSet<Transac
     @Expose @SerializedName("$merchant_initiated_transaction")
         private Boolean merchantInitiatedTransaction;
     @Expose @SerializedName(VERIFICATION_PHONE_NUMBER) private String verificationPhoneNumber;
+    @Expose @SerializedName("$digital_orders") private List<DigitalOrder> digitalOrders;
+    @Expose @SerializedName("$receiver_wallet_address") private String receiverWalletAddress;
+    @Expose @SerializedName("$receiver_external_address") private Boolean receiverExternalAddress;
 
 
     @Override
@@ -224,6 +229,33 @@ public class TransactionFieldSet extends BaseAppBrowserSiteBrandFieldSet<Transac
 
     public TransactionFieldSet setVerificationPhoneNumber(String verificationPhoneNumber) {
         this.verificationPhoneNumber = verificationPhoneNumber;
+        return this;
+    }
+
+    public List<DigitalOrder> getDigitalOrders() {
+        return digitalOrders;
+    }
+
+    public TransactionFieldSet setDigitalOrders(List<DigitalOrder> digitalOrders) {
+        this.digitalOrders = digitalOrders;
+        return this;
+    }
+
+    public String getReceiverWalletAddress() {
+        return receiverWalletAddress;
+    }
+
+    public TransactionFieldSet setReceiverWalletAddress(String receiverWalletAddress) {
+        this.receiverWalletAddress = receiverWalletAddress;
+        return this;
+    }
+
+    public Boolean getReceiverExternalAddress() {
+        return receiverExternalAddress;
+    }
+
+    public TransactionFieldSet setReceiverExternalAddress(Boolean receiverExternalAddress) {
+        this.receiverExternalAddress = receiverExternalAddress;
         return this;
     }
 }

--- a/src/test/java/com/siftscience/ChargebackEventTest.java
+++ b/src/test/java/com/siftscience/ChargebackEventTest.java
@@ -37,7 +37,8 @@ public class ChargebackEventTest {
                 "      \"$region\"    : \"New Hampshire\",\n" +
                 "      \"$zipcode\"   : \"03257\"\n" +
                 "    }\n" +
-                "  }\n" +
+                "  }\n," +
+                "  \"$ach_return_code\"   : \"B02\"\n" +
                 "}\n";
 
         // Start a new mock server and enqueue a mock response.
@@ -66,7 +67,8 @@ public class ChargebackEventTest {
                 .setTransactionId("719637215")
                 .setChargebackState("$lost")
                 .setChargebackReason("$duplicate")
-                .setMerchantProfile(TestUtils.sampleMerchantProfile()));
+                .setMerchantProfile(TestUtils.sampleMerchantProfile())
+                .setAchReturnCode("B02"));
 
         EventResponse siftResponse = request.send();
 

--- a/src/test/java/com/siftscience/TestUtils.java
+++ b/src/test/java/com/siftscience/TestUtils.java
@@ -3,6 +3,7 @@ package com.siftscience;
 import com.siftscience.model.Address;
 import com.siftscience.model.Booking;
 import com.siftscience.model.CreditPoint;
+import com.siftscience.model.DigitalOrder;
 import com.siftscience.model.Discount;
 import com.siftscience.model.Guest;
 import com.siftscience.model.Item;
@@ -93,6 +94,21 @@ public class TestUtils {
                 .setShortenedIbanFirst6("FR7630")
                 .setShortenedIbanLast4("1234")
                 .setSepaDirectDebitMandate(true);
+    }
+
+    static PaymentMethod samplePaymentMethodWalletFields() {
+        return new PaymentMethod()
+            .setWalletAddress("ZplYVmchAoywfMvC8jCiKlBLfKSBiFtHU6")
+            .setWalletType("$crypto");
+    }
+
+    static DigitalOrder sampleDigitalOrder() {
+        return new DigitalOrder()
+            .setDigitalAsset("BTC")
+            .setPair("BTC_USD")
+            .setAssetType("$crypto")
+            .setOrderType("$market")
+            .setVolume("6.0");
     }
 
     static List<String> sampleTags1() {

--- a/src/test/java/com/siftscience/TransactionEventTest.java
+++ b/src/test/java/com/siftscience/TransactionEventTest.java
@@ -2,6 +2,11 @@ package com.siftscience;
 
 import static java.net.HttpURLConnection.HTTP_OK;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import com.siftscience.model.DigitalOrder;
+import com.siftscience.model.PaymentMethod;
 import com.siftscience.model.TransactionFieldSet;
 import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockResponse;
@@ -580,6 +585,89 @@ public class TransactionEventTest {
         Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
         JSONAssert.assertEquals(response.getBody().readUtf8(),
                 siftResponse.getBody().toJson(), true);
+
+        server.shutdown();
+    }
+
+    @Test
+    public void testTransactionEventWithCryptoFields() throws Exception {
+        String expectedRequestBody = "{\n" +
+            "  \"$type\"             : \"$transaction\",\n" +
+            "  \"$api_key\"          : \"YOUR_API_KEY\",\n" +
+            "  \"$user_id\"          : \"billy_jones_301\",\n" +
+            "  \"$amount\"           : 506790000,\n" +
+            "  \"$currency_code\"    : \"USD\",\n" +
+            "\n" +
+            "  \"$user_email\"       : \"bill@gmail.com\",\n" +
+            "  \"$transaction_type\" : \"$buy\",\n" +
+            "  \"$transaction_id\"   : \"719637215\",\n" +
+            "\n" +
+            "  \"$payment_method\"   : {\n" +
+            "      \"$wallet_address\" : \"ZplYVmchAoywfMvC8jCiKlBLfKSBiFtHU6\",\n" +
+            "      \"$wallet_type\"    : \"$crypto\",\n" +
+            "  },\n" +
+            "  \"$digital_orders\" : [\n" +
+            "    {\n" +
+            "      \"$digital_asset\" : \"BTC\",\n" +
+            "      \"$pair\"          : \"BTC_USD\",\n" +
+            "      \"$asset_type\"    : \"$crypto\",\n" +
+            "      \"$order_type\"    : \"$market\",\n" +
+            "      \"$volume\"        : \"6.0\",\n" +
+            "    }\n" +
+            "  ],\n" +
+            "  \"$receiver_wallet_address\"   : \"jx17gVqSyo9m4MrhuhuYEUXdCicdof85Bl\",\n" +
+            "  \"$receiver_external_address\" : true,\n" +
+            "}";
+
+        // Start a new mock server and enqueue a mock response.
+        MockWebServer server = new MockWebServer();
+        MockResponse response = new MockResponse();
+        response.setResponseCode(HTTP_OK);
+        response.setBody("{\n" +
+            "    \"status\" : 0,\n" +
+            "    \"error_message\" : \"OK\",\n" +
+            "    \"time\" : 1327604222,\n" +
+            "    \"request\" : \"" + TestUtils.unescapeJson(expectedRequestBody) + "\"\n" +
+            "}");
+        server.enqueue(response);
+        server.start();
+
+        // Create a new client and link it to the mock server.
+        SiftClient client = new SiftClient("YOUR_API_KEY", "YOUR_ACCOUNT_ID",
+            new OkHttpClient.Builder()
+                .addInterceptor(OkHttpUtils.urlRewritingInterceptor(server))
+                .build());
+
+        // Build the request body.
+        // Digital orders.
+        List<DigitalOrder> digitalOrderList = new ArrayList<>();
+        digitalOrderList.add(TestUtils.sampleDigitalOrder());
+
+        // Build and execute the request against the mock server.
+        EventRequest request = client.buildRequest(new TransactionFieldSet()
+            .setUserId("billy_jones_301")
+            .setAmount(506790000L)
+            .setCurrencyCode("USD")
+            .setUserEmail("bill@gmail.com")
+            .setTransactionType("$buy")
+            .setTransactionId("719637215")
+            .setPaymentMethod(TestUtils.samplePaymentMethodWalletFields())
+            .setDigitalOrders(digitalOrderList)
+            .setReceiverWalletAddress("jx17gVqSyo9m4MrhuhuYEUXdCicdof85Bl")
+            .setReceiverExternalAddress(true));
+        EventResponse siftResponse = request.send();
+
+        // Verify the request.
+        RecordedRequest request1 = server.takeRequest();
+        Assert.assertEquals("POST", request1.getMethod());
+        Assert.assertEquals("/v205/events", request1.getPath());
+        JSONAssert.assertEquals(expectedRequestBody, request.getFieldSet().toJson(), true);
+
+        // Verify the response.
+        Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
+        Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
+        JSONAssert.assertEquals(response.getBody().readUtf8(),
+            siftResponse.getBody().toJson(), true);
 
         server.shutdown();
     }

--- a/src/test/java/com/siftscience/UpdateOrderEventTest.java
+++ b/src/test/java/com/siftscience/UpdateOrderEventTest.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.siftscience.model.Booking;
+import com.siftscience.model.DigitalOrder;
 import com.siftscience.model.Item;
 import com.siftscience.model.PaymentMethod;
 import com.siftscience.model.Promotion;
@@ -582,6 +583,93 @@ public class UpdateOrderEventTest {
                 .setCurrencyCode("USD")
                 .setPaymentMethods(paymentMethodList)
                 .setMerchantProfile(TestUtils.sampleMerchantProfile()));
+
+        EventResponse siftResponse = request.send();
+
+        // Verify the request.
+        RecordedRequest request1 = server.takeRequest();
+        Assert.assertEquals("POST", request1.getMethod());
+        Assert.assertEquals("/v205/events", request1.getPath());
+        JSONAssert.assertEquals(expectedRequestBody, request.getFieldSet().toJson(), true);
+
+        // Verify the response.
+        Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
+        Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
+        JSONAssert.assertEquals(response.getBody().readUtf8(),
+            siftResponse.getBody().toJson(), true);
+
+        server.shutdown();
+    }
+
+    @Test
+    public void testUpdateOrderEventWithCryptoFields()
+        throws JSONException, IOException, InterruptedException {
+
+        // The expected JSON payload of the request.
+        String expectedRequestBody = "{\n" +
+            "  \"$type\": \"$update_order\",\n" +
+            "  \"$api_key\": \"YOUR_API_KEY\",\n" +
+            "  \"$user_id\": \"billy_jones_301\",\n" +
+            "  \"$session_id\": \"gigtleqddo84l8cm15qe4il\",\n" +
+            "  \"$order_id\": \"ORDER-28168441\",\n" +
+            "  \"$user_email\": \"bill@gmail.com\",\n" +
+            "  \"$amount\": 115940000,\n" +
+            "  \"$currency_code\": \"USD\",\n" +
+            "  \"$payment_methods\": [\n" +
+            "    {\n" +
+            "      \"$wallet_address\": \"ZplYVmchAoywfMvC8jCiKlBLfKSBiFtHU6\",\n" +
+            "      \"$wallet_type\": \"$crypto\",\n" +
+            "    }\n" +
+            "  ],\n" +
+            "  \"$digital_orders\" : [\n" +
+            "    {\n" +
+            "      \"$digital_asset\" : \"BTC\",\n" +
+            "      \"$pair\"          : \"BTC_USD\",\n" +
+            "      \"$asset_type\"    : \"$crypto\",\n" +
+            "      \"$order_type\"    : \"$market\",\n" +
+            "      \"$volume\"        : \"6.0\",\n" +
+            "    }\n" +
+            "  ],\n" +
+            "}\n";
+
+        // Start a new mock server and enqueue a mock response.
+        MockWebServer server = new MockWebServer();
+        MockResponse response = new MockResponse();
+        response.setResponseCode(HTTP_OK);
+        response.setBody("{\n" +
+            "    \"status\" : 0,\n" +
+            "    \"error_message\" : \"OK\",\n" +
+            "    \"time\" : 1327604222,\n" +
+            "    \"request\" : \"" + TestUtils.unescapeJson(expectedRequestBody) + "\"\n" +
+            "}");
+        server.enqueue(response);
+        server.start();
+
+        // Create a new client and link it to the mock server.
+        SiftClient client = new SiftClient("YOUR_API_KEY", "YOUR_ACCOUNT_ID",
+            new OkHttpClient.Builder()
+                .addInterceptor(OkHttpUtils.urlRewritingInterceptor(server))
+                .build());
+
+        // Payment methods.
+        List<PaymentMethod> paymentMethodList = new ArrayList<>();
+        paymentMethodList.add(TestUtils.samplePaymentMethodWalletFields());
+
+        // Digital orders.
+        List<DigitalOrder> digitalOrderList = new ArrayList<>();
+        digitalOrderList.add(TestUtils.sampleDigitalOrder());
+
+        // Build and execute the request against the mock server.
+        EventRequest request = client.buildRequest(
+            new UpdateOrderFieldSet()
+                .setUserId("billy_jones_301")
+                .setSessionId("gigtleqddo84l8cm15qe4il")
+                .setOrderId("ORDER-28168441")
+                .setUserEmail("bill@gmail.com")
+                .setAmount(115940000L)
+                .setCurrencyCode("USD")
+                .setPaymentMethods(paymentMethodList)
+                .setDigitalOrders(digitalOrderList));
 
         EventResponse siftResponse = request.send();
 


### PR DESCRIPTION
Jira:
- https://sift.atlassian.net/browse/PAY-3228
- https://sift.atlassian.net/browse/PAY-3222

Changes overview:
- New field `$ach_return_code` is added to the `$chargeback` event according to the recent Sift API update ([PR](https://github.com/SiftScience/code/pull/51525), [marketing-site](https://sift.com/developers/docs/curl/events-api/reserved-events/chargeback))
- Set of new Crypto API fields is added to various complex fields and events (more details at [PAY-3222](https://sift.atlassian.net/browse/PAY-3222)
- Updated tests