### PR TITLE
Adding the sift-integration test for the sift-java workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
             export GIT_SSH_COMMAND='ssh -i ~/.ssh/id_rsa_4cc71df295873cf6614e465ac82ad7c9'
             git clone git@github.com:SiftScience/sift-java-integration-app.git
             cd sift-java-integration-app
-            unzip -j ../build/distributions/sift-java-3.10.0.zip -d app/libs/
+            unzip -j ../build/distributions/sift-java-*.zip -d app/libs/
 
       - run:
           name: Running tests in sift-java-integration-app
@@ -107,4 +107,8 @@ workflows:
       - build:
           context: *context
       - java_integration:
+#           filters:
+#             branches:
+#               only:
+#                 - master
           context: *context

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
             export GIT_SSH_COMMAND='ssh -i ~/.ssh/id_rsa_4cc71df295873cf6614e465ac82ad7c9'
             git clone git@github.com:SiftScience/sift-java-integration-app.git
             cd sift-java-integration-app
-            unzip ../build/distributions/sift-java-3.10.0.zip -d app/libs/
+            unzip -j ../build/distributions/sift-java-3.10.0.zip -d app/libs/
 
       - run:
           name: Running tests in sift-java-integration-app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,8 +108,8 @@ workflows:
       - build:
           context: *context
       - java_integration:
-#           filters:
-#             branches:
-#               only:
-#                 - master
+          filters:
+            branches:
+              only:
+                - master
           context: *context

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,9 +91,10 @@ jobs:
           name: Clone sift-java-integration-app and extract sift-java
           command: |
             export GIT_SSH_COMMAND='ssh -i ~/.ssh/id_rsa_4cc71df295873cf6614e465ac82ad7c9'
+            version=$(./gradlew properties -q | grep "version:" | awk '{print $2}')
             git clone git@github.com:SiftScience/sift-java-integration-app.git
             cd sift-java-integration-app
-            unzip -j ../build/distributions/sift-java-*.zip -d app/libs/
+            unzip -j ../build/distributions/sift-java-${version}.zip -d app/libs/
 
       - run:
           name: Running tests in sift-java-integration-app
@@ -107,8 +108,8 @@ workflows:
       - build:
           context: *context
       - java_integration:
-          filters:
-            branches:
-              only:
-                - master
+#           filters:
+#             branches:
+#               only:
+#                 - master
           context: *context

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,8 +107,8 @@ workflows:
       - build:
           context: *context
       - java_integration:
-#           filters:
-#             branches:
-#               only:
-#                 - master
+          filters:
+            branches:
+              only:
+                - master
           context: *context

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
           name: Clone sift-java-integration-app and extract sift-java
           command: |
             export GIT_SSH_COMMAND='ssh -i ~/.ssh/id_rsa_4cc71df295873cf6614e465ac82ad7c9'
-            version=$(./gradlew properties -q | grep "version:" | awk '{print $2}')
+            version=$(./gradlew properties -q | grep -E "^version:" | awk '{print $2}')
             git clone git@github.com:SiftScience/sift-java-integration-app.git
             cd sift-java-integration-app
             unzip -j ../build/distributions/sift-java-${version}.zip -d app/libs/
@@ -108,8 +108,4 @@ workflows:
       - build:
           context: *context
       - java_integration:
-          filters:
-            branches:
-              only:
-                - master
           context: *context

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,11 @@ commands:
             done < github_slack
             rm github_slack
 
+context: &context
+  - slack-templates
+  - slack_Oauth
+  - Github_Slack_UserMapping
+
 jobs:
   build:
     docker:
@@ -62,11 +67,44 @@ jobs:
       - slack/notify:
           <<: *slack_notify
 
+  java_integration:
+    docker:
+      - image: circleci/openjdk:8-jdk
+    working_directory: ~/repo
+
+    environment:
+      TERM: dumb
+      GRADLE_OPTS: -Dorg.gradle.project.sonatypeUsername=username -Dorg.gradle.project.sonatypePassword=password
+
+    steps:
+      - checkout
+      - export_slack_id
+      - run:
+          name: Build and packaged sift-java
+          command: ./gradlew distZip
+
+      - add_ssh_keys:
+          fingerprints:
+            - "4c:c7:1d:f2:95:87:3c:f6:61:4e:46:5a:c8:2a:d7:c9"
+
+      - run:
+          name: Clone sift-java-integration-app and extract sift-java
+          command: |
+            export GIT_SSH_COMMAND='ssh -i ~/.ssh/id_rsa_4cc71df295873cf6614e465ac82ad7c9'
+            git clone git@github.com:SiftScience/sift-java-integration-app.git
+            cd sift-java-integration-app
+            unzip ../build/distributions/sift-java-3.10.0.zip -d app/libs/
+
+      - run:
+          name: Running tests in sift-java-integration-app
+          command: |
+            cd sift-java-integration-app
+            ./gradlew test
+
 workflows:
   sift-java:
     jobs:
       - build:
-          context:
-            - slack-templates
-            - slack_Oauth
-            - Github_Slack_UserMapping
+          context: *context
+      - java_integration:
+          context: *context

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,4 +108,8 @@ workflows:
       - build:
           context: *context
       - java_integration:
+          filters:
+            branches:
+              only:
+                - master
           context: *context


### PR DESCRIPTION
## Purpose:
- https://sift.atlassian.net/browse/CI-11587

## Technical overview:
- Build and package the sift-java project into a distribution zip file.
- Add SSH keys with specified fingerprints for secure access.
- Clone the sift-java-integration-app repository, and extract the contents of sift-java-3.10.0.zip directly into the app/libs/ directory.
- Change to the sift-java-integration-app directory and run the tests using Gradle.

## Testing plan:
- https://app.circleci.com/pipelines/github/SiftScience/sift-java/218/workflows/3341d8a4-105c-4934-8577-0cd5b46cbc2b

## Deployment plan:
- Merge the PR.


