### PR TITLE
API-7197: Implement missing fields in Events API

### DIFF
--- a/CHANGES.MD
+++ b/CHANGES.MD
@@ -1,3 +1,9 @@
+3.11.0 (2023-06-29)
+=================
+- Add support for `$user_email` field to `$add_item_to_cart`, `$add_promotion`, `$content_status`, `$flag_content`, `$remove_item_from_cart` and `$update_password` events
+- Add support for `$shipping_carrier` and `$shipping_tracking_numbers` fields to `$create_order` and `$update_order` events
+- Add support for `reason` field to `flag_content` event
+
 3.10.0 (2023-06-06)
 =================
 - Remove support for `$keyless_user_id` field for Events API 

--- a/CHANGES.MD
+++ b/CHANGES.MD
@@ -2,7 +2,7 @@
 =================
 - Add support for `$user_email` field to `$add_item_to_cart`, `$add_promotion`, `$content_status`, `$flag_content`, `$remove_item_from_cart` and `$update_password` events
 - Add support for `$shipping_carrier` and `$shipping_tracking_numbers` fields to `$create_order` and `$update_order` events
-- Add support for `reason` field to `flag_content` event
+- Add support for `$reason` field to `$flag_content` event
 
 3.10.0 (2023-06-06)
 =================

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Java 1.7 or later.
 <dependency>
     <groupId>com.siftscience</groupId>
     <artifactId>sift-java</artifactId>
-    <version>3.10.0</version>
+    <version>3.11.0</version>
 </dependency>
 ```
 ### Gradle
 ```
 dependencies {
-    compile 'com.siftscience:sift-java:3.10.0'
+    compile 'com.siftscience:sift-java:3.11.0'
 }
 ```
 ### Other

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'signing'
 apply plugin: 'java-library-distribution'
 
 group = 'com.siftscience'
-version = '3.10.0'
+version = '3.11.0'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/siftscience/Constants.java
+++ b/src/main/java/com/siftscience/Constants.java
@@ -3,6 +3,6 @@ package com.siftscience;
 public class Constants {
 
     public static final String API_VERSION = "v205";
-    public static final String LIB_VERSION = "3.8.0";
+    public static final String LIB_VERSION = "3.11.0";
     public static final String USER_AGENT_HEADER = String.format("SiftScience/%s sift-java/%s", API_VERSION, LIB_VERSION);
 }

--- a/src/main/java/com/siftscience/FieldSet.java
+++ b/src/main/java/com/siftscience/FieldSet.java
@@ -36,6 +36,7 @@ public abstract class FieldSet<T extends FieldSet<T>> {
     public static final String TIME = "$time";
     public static final String IS_BAD = "$is_bad";
     public static final String ABUSE_TYPE = "$abuse_type";
+    public static final String USER_EMAIL = "$user_email";
     public static final String VERIFICATION_PHONE_NUMBER = "$verification_phone_number";
 
     // Serialization happens in two stages. First, the object is serialized with `defaultGson`

--- a/src/main/java/com/siftscience/model/AddItemToCartFieldSet.java
+++ b/src/main/java/com/siftscience/model/AddItemToCartFieldSet.java
@@ -9,6 +9,7 @@ public class AddItemToCartFieldSet extends BaseAppBrowserSiteBrandFieldSet<AddIt
     }
 
     @Expose @SerializedName("$item") private Item item;
+    @Expose @SerializedName("$user_email") private String userEmail;
     @Expose @SerializedName(VERIFICATION_PHONE_NUMBER) private String verificationPhoneNumber;
 
     @Override
@@ -22,6 +23,15 @@ public class AddItemToCartFieldSet extends BaseAppBrowserSiteBrandFieldSet<AddIt
 
     public AddItemToCartFieldSet setItem(Item item) {
         this.item = item;
+        return this;
+    }
+
+    public String getUserEmail() {
+        return userEmail;
+    }
+
+    public AddItemToCartFieldSet setUserEmail(String userEmail) {
+        this.userEmail = userEmail;
         return this;
     }
 

--- a/src/main/java/com/siftscience/model/AddItemToCartFieldSet.java
+++ b/src/main/java/com/siftscience/model/AddItemToCartFieldSet.java
@@ -9,7 +9,7 @@ public class AddItemToCartFieldSet extends BaseAppBrowserSiteBrandFieldSet<AddIt
     }
 
     @Expose @SerializedName("$item") private Item item;
-    @Expose @SerializedName("$user_email") private String userEmail;
+    @Expose @SerializedName(USER_EMAIL) private String userEmail;
     @Expose @SerializedName(VERIFICATION_PHONE_NUMBER) private String verificationPhoneNumber;
 
     @Override

--- a/src/main/java/com/siftscience/model/AddPromotionFieldSet.java
+++ b/src/main/java/com/siftscience/model/AddPromotionFieldSet.java
@@ -11,7 +11,7 @@ public class AddPromotionFieldSet extends BaseAppBrowserSiteBrandFieldSet<AddPro
     }
 
     @Expose @SerializedName("$promotions") private List<Promotion> promotions;
-    @Expose @SerializedName("$user_email") private String userEmail;
+    @Expose @SerializedName(USER_EMAIL) private String userEmail;
     @Expose @SerializedName(VERIFICATION_PHONE_NUMBER) private String verificationPhoneNumber;
 
     @Override

--- a/src/main/java/com/siftscience/model/AddPromotionFieldSet.java
+++ b/src/main/java/com/siftscience/model/AddPromotionFieldSet.java
@@ -11,6 +11,7 @@ public class AddPromotionFieldSet extends BaseAppBrowserSiteBrandFieldSet<AddPro
     }
 
     @Expose @SerializedName("$promotions") private List<Promotion> promotions;
+    @Expose @SerializedName("$user_email") private String userEmail;
     @Expose @SerializedName(VERIFICATION_PHONE_NUMBER) private String verificationPhoneNumber;
 
     @Override
@@ -24,6 +25,15 @@ public class AddPromotionFieldSet extends BaseAppBrowserSiteBrandFieldSet<AddPro
 
     public AddPromotionFieldSet setPromotions(List<Promotion> promotions) {
         this.promotions = promotions;
+        return this;
+    }
+
+    public String getUserEmail() {
+        return userEmail;
+    }
+
+    public AddPromotionFieldSet setUserEmail(String userEmail) {
+        this.userEmail = userEmail;
         return this;
     }
 

--- a/src/main/java/com/siftscience/model/BaseAccountFieldSet.java
+++ b/src/main/java/com/siftscience/model/BaseAccountFieldSet.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public abstract class BaseAccountFieldSet<T extends BaseAccountFieldSet<T>>
         extends BaseAppBrowserSiteBrandFieldSet<T> {
-    @Expose @SerializedName("$user_email") private String userEmail;
+    @Expose @SerializedName(USER_EMAIL) private String userEmail;
     @Expose @SerializedName("$name") private String name;
     @Expose @SerializedName("$phone") private String phone;
     @Expose @SerializedName("$referrer_user_id") private String referrerUserId;

--- a/src/main/java/com/siftscience/model/BaseOrderFieldSet.java
+++ b/src/main/java/com/siftscience/model/BaseOrderFieldSet.java
@@ -19,6 +19,8 @@ public abstract class BaseOrderFieldSet<T extends BaseOrderFieldSet<T>>
     @Expose @SerializedName("$seller_user_id") private String sellerUserId;
     @Expose @SerializedName("$promotions") private List<Promotion> promotions;
     @Expose @SerializedName("$shipping_method") private String shippingMethod;
+    @Expose @SerializedName("shipping_carrier") private String shippingCarrier;
+    @Expose @SerializedName("shipping_tracking_numbers") private List<String> shippingTrackingNumbers;
     @Expose @SerializedName("$bookings") private List<Booking> bookings;
     @Expose @SerializedName("$ordered_from") private OrderedFrom orderedFrom;
     @Expose @SerializedName("$merchant_profile") private MerchantProfile merchantProfile;
@@ -143,6 +145,24 @@ public abstract class BaseOrderFieldSet<T extends BaseOrderFieldSet<T>>
 
     public T setShippingMethod(String shippingMethod) {
         this.shippingMethod = shippingMethod;
+        return (T) this;
+    }
+
+    public String getShippingCarrier() {
+        return shippingCarrier;
+    }
+
+    public T setShippingCarrier(String shippingCarrier) {
+        this.shippingCarrier = shippingCarrier;
+        return (T) this;
+    }
+
+    public List<String> getShippingTrackingNumbers() {
+        return shippingTrackingNumbers;
+    }
+
+    public T setShippingTrackingNumbers(List<String> shippingTrackingNumbers) {
+        this.shippingTrackingNumbers = shippingTrackingNumbers;
         return (T) this;
     }
 

--- a/src/main/java/com/siftscience/model/BaseOrderFieldSet.java
+++ b/src/main/java/com/siftscience/model/BaseOrderFieldSet.java
@@ -19,8 +19,8 @@ public abstract class BaseOrderFieldSet<T extends BaseOrderFieldSet<T>>
     @Expose @SerializedName("$seller_user_id") private String sellerUserId;
     @Expose @SerializedName("$promotions") private List<Promotion> promotions;
     @Expose @SerializedName("$shipping_method") private String shippingMethod;
-    @Expose @SerializedName("shipping_carrier") private String shippingCarrier;
-    @Expose @SerializedName("shipping_tracking_numbers") private List<String> shippingTrackingNumbers;
+    @Expose @SerializedName("$shipping_carrier") private String shippingCarrier;
+    @Expose @SerializedName("$shipping_tracking_numbers") private List<String> shippingTrackingNumbers;
     @Expose @SerializedName("$bookings") private List<Booking> bookings;
     @Expose @SerializedName("$ordered_from") private OrderedFrom orderedFrom;
     @Expose @SerializedName("$merchant_profile") private MerchantProfile merchantProfile;

--- a/src/main/java/com/siftscience/model/BaseOrderFieldSet.java
+++ b/src/main/java/com/siftscience/model/BaseOrderFieldSet.java
@@ -8,7 +8,7 @@ import java.util.List;
 public abstract class BaseOrderFieldSet<T extends BaseOrderFieldSet<T>>
         extends BaseAppBrowserSiteBrandFieldSet<T> {
     @Expose @SerializedName("$order_id") private String orderId;
-    @Expose @SerializedName("$user_email") private String userEmail;
+    @Expose @SerializedName(USER_EMAIL) private String userEmail;
     @Expose @SerializedName("$amount") private Long amount;
     @Expose @SerializedName("$currency_code") private String currencyCode;
     @Expose @SerializedName("$billing_address") private Address billingAddress;

--- a/src/main/java/com/siftscience/model/ContentStatusFieldSet.java
+++ b/src/main/java/com/siftscience/model/ContentStatusFieldSet.java
@@ -10,6 +10,7 @@ public class ContentStatusFieldSet extends BaseAppBrowserSiteBrandFieldSet<Conte
 
     @Expose @SerializedName("$content_id") private String contentId;
     @Expose @SerializedName("$status") private String status;
+    @Expose @SerializedName("$user_email") private String userEmail;
     @Expose @SerializedName(VERIFICATION_PHONE_NUMBER) private String verificationPhoneNumber;
 
     @Override
@@ -32,6 +33,15 @@ public class ContentStatusFieldSet extends BaseAppBrowserSiteBrandFieldSet<Conte
 
     public ContentStatusFieldSet setContentId(String contentId) {
         this.contentId = contentId;
+        return this;
+    }
+
+    public String getUserEmail() {
+        return userEmail;
+    }
+
+    public ContentStatusFieldSet setUserEmail(String userEmail) {
+        this.userEmail = userEmail;
         return this;
     }
 

--- a/src/main/java/com/siftscience/model/ContentStatusFieldSet.java
+++ b/src/main/java/com/siftscience/model/ContentStatusFieldSet.java
@@ -10,7 +10,7 @@ public class ContentStatusFieldSet extends BaseAppBrowserSiteBrandFieldSet<Conte
 
     @Expose @SerializedName("$content_id") private String contentId;
     @Expose @SerializedName("$status") private String status;
-    @Expose @SerializedName("$user_email") private String userEmail;
+    @Expose @SerializedName(USER_EMAIL) private String userEmail;
     @Expose @SerializedName(VERIFICATION_PHONE_NUMBER) private String verificationPhoneNumber;
 
     @Override

--- a/src/main/java/com/siftscience/model/CustomEventFieldSet.java
+++ b/src/main/java/com/siftscience/model/CustomEventFieldSet.java
@@ -9,7 +9,7 @@ public class CustomEventFieldSet extends BaseAppBrowserSiteBrandFieldSet<CustomE
     }
 
     @Expose @SerializedName(EVENT_TYPE) private String eventType;
-    @Expose @SerializedName("$user_email") private String userEmail;
+    @Expose @SerializedName(USER_EMAIL) private String userEmail;
     @Expose @SerializedName("$name") private String name;
     @Expose @SerializedName("$phone") private String phone;
     @Expose @SerializedName(VERIFICATION_PHONE_NUMBER) private String verificationPhoneNumber;

--- a/src/main/java/com/siftscience/model/FlagContentFieldSet.java
+++ b/src/main/java/com/siftscience/model/FlagContentFieldSet.java
@@ -10,7 +10,7 @@ public class FlagContentFieldSet extends EventsApiRequestFieldSet<FlagContentFie
 
     @Expose @SerializedName("$content_id") private String contentId;
     @Expose @SerializedName("$flagged_by") private String flaggedBy;
-    @Expose @SerializedName("$user_email") private String userEmail;
+    @Expose @SerializedName(USER_EMAIL) private String userEmail;
     @Expose @SerializedName(VERIFICATION_PHONE_NUMBER) private String verificationPhoneNumber;
 
     @Override

--- a/src/main/java/com/siftscience/model/FlagContentFieldSet.java
+++ b/src/main/java/com/siftscience/model/FlagContentFieldSet.java
@@ -10,6 +10,7 @@ public class FlagContentFieldSet extends EventsApiRequestFieldSet<FlagContentFie
 
     @Expose @SerializedName("$content_id") private String contentId;
     @Expose @SerializedName("$flagged_by") private String flaggedBy;
+    @Expose @SerializedName("$user_email") private String userEmail;
     @Expose @SerializedName(VERIFICATION_PHONE_NUMBER) private String verificationPhoneNumber;
 
     @Override
@@ -32,6 +33,15 @@ public class FlagContentFieldSet extends EventsApiRequestFieldSet<FlagContentFie
 
     public FlagContentFieldSet setFlaggedBy(String flaggedBy) {
         this.flaggedBy = flaggedBy;
+        return this;
+    }
+
+    public String getUserEmail() {
+        return userEmail;
+    }
+
+    public FlagContentFieldSet setUserEmail(String userEmail) {
+        this.userEmail = userEmail;
         return this;
     }
 

--- a/src/main/java/com/siftscience/model/FlagContentFieldSet.java
+++ b/src/main/java/com/siftscience/model/FlagContentFieldSet.java
@@ -8,8 +8,31 @@ public class FlagContentFieldSet extends EventsApiRequestFieldSet<FlagContentFie
         return gson.fromJson(json, FlagContentFieldSet.class);
     }
 
+    public enum FlagContentReason {
+        TOXIC("$toxic"),
+        IRRELEVANT("$irrelevant"),
+        COMMERCIAL("$commercial"),
+        PHISHING("$phishing"),
+        PRIVATE("$private"),
+        SCAM("$scam"),
+        COPYRIGHT("$copyright"),
+        OTHER("$other");
+
+        public final String value;
+
+        FlagContentReason(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+    }
+
     @Expose @SerializedName("$content_id") private String contentId;
     @Expose @SerializedName("$flagged_by") private String flaggedBy;
+    @Expose @SerializedName("$reason") private String reason;
     @Expose @SerializedName(USER_EMAIL) private String userEmail;
     @Expose @SerializedName(VERIFICATION_PHONE_NUMBER) private String verificationPhoneNumber;
 
@@ -33,6 +56,15 @@ public class FlagContentFieldSet extends EventsApiRequestFieldSet<FlagContentFie
 
     public FlagContentFieldSet setFlaggedBy(String flaggedBy) {
         this.flaggedBy = flaggedBy;
+        return this;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public FlagContentFieldSet setReason(FlagContentReason reason) {
+        this.reason = reason.value;
         return this;
     }
 

--- a/src/main/java/com/siftscience/model/LoginFieldSet.java
+++ b/src/main/java/com/siftscience/model/LoginFieldSet.java
@@ -15,7 +15,7 @@ public class LoginFieldSet extends BaseAppBrowserSiteBrandFieldSet<LoginFieldSet
     @Expose @SerializedName("$username") private String username;
     @Expose @SerializedName("$social_sign_on_type") private String socialSignOnType;
     @Expose @SerializedName("$account_types") private List<String> accountTypes;
-    @Expose @SerializedName("$user_email") private String userEmail;
+    @Expose @SerializedName(USER_EMAIL) private String userEmail;
     @Expose @SerializedName(VERIFICATION_PHONE_NUMBER) private String verificationPhoneNumber;
 
     @Override

--- a/src/main/java/com/siftscience/model/RemoveItemFromCartFieldSet.java
+++ b/src/main/java/com/siftscience/model/RemoveItemFromCartFieldSet.java
@@ -9,7 +9,7 @@ public class RemoveItemFromCartFieldSet extends BaseAppBrowserSiteBrandFieldSet<
     }
 
     @Expose @SerializedName("$item") private Item item;
-    @Expose @SerializedName("$user_email") private String userEmail;
+    @Expose @SerializedName(USER_EMAIL) private String userEmail;
     @Expose @SerializedName(VERIFICATION_PHONE_NUMBER) private String verificationPhoneNumber;
 
     @Override

--- a/src/main/java/com/siftscience/model/RemoveItemFromCartFieldSet.java
+++ b/src/main/java/com/siftscience/model/RemoveItemFromCartFieldSet.java
@@ -9,6 +9,7 @@ public class RemoveItemFromCartFieldSet extends BaseAppBrowserSiteBrandFieldSet<
     }
 
     @Expose @SerializedName("$item") private Item item;
+    @Expose @SerializedName("$user_email") private String userEmail;
     @Expose @SerializedName(VERIFICATION_PHONE_NUMBER) private String verificationPhoneNumber;
 
     @Override
@@ -22,6 +23,15 @@ public class RemoveItemFromCartFieldSet extends BaseAppBrowserSiteBrandFieldSet<
 
     public RemoveItemFromCartFieldSet setItem(Item item) {
         this.item = item;
+        return this;
+    }
+
+    public String getUserEmail() {
+        return userEmail;
+    }
+
+    public RemoveItemFromCartFieldSet setUserEmail(String userEmail) {
+        this.userEmail = userEmail;
         return this;
     }
 

--- a/src/main/java/com/siftscience/model/TransactionFieldSet.java
+++ b/src/main/java/com/siftscience/model/TransactionFieldSet.java
@@ -8,7 +8,7 @@ import com.google.gson.annotations.SerializedName;
 public class TransactionFieldSet extends BaseAppBrowserSiteBrandFieldSet<TransactionFieldSet> {
     @Expose @SerializedName("$amount") private Long amount;
     @Expose @SerializedName("$currency_code") private String currencyCode;
-    @Expose @SerializedName("$user_email") private String userEmail;
+    @Expose @SerializedName(USER_EMAIL) private String userEmail;
     @Expose @SerializedName("$transaction_type") private String transactionType;
     @Expose @SerializedName("$transaction_status") private String transactionStatus;
     @Expose @SerializedName("$order_id") private String orderId;

--- a/src/main/java/com/siftscience/model/UpdatePasswordFieldSet.java
+++ b/src/main/java/com/siftscience/model/UpdatePasswordFieldSet.java
@@ -10,6 +10,7 @@ public class UpdatePasswordFieldSet extends BaseAppBrowserSiteBrandFieldSet<Upda
 
     @Expose @SerializedName("$reason") private String reason;
     @Expose @SerializedName("$status") private String status;
+    @Expose @SerializedName("$user_email") private String userEmail;
     @Expose @SerializedName(VERIFICATION_PHONE_NUMBER) private String verificationPhoneNumber;
 
     @Override
@@ -28,6 +29,15 @@ public class UpdatePasswordFieldSet extends BaseAppBrowserSiteBrandFieldSet<Upda
 
     public UpdatePasswordFieldSet setStatus(String status) {
         this.status = status;
+        return this;
+    }
+
+    public String getUserEmail() {
+        return userEmail;
+    }
+
+    public UpdatePasswordFieldSet setUserEmail(String userEmail) {
+        this.userEmail = userEmail;
         return this;
     }
 

--- a/src/main/java/com/siftscience/model/UpdatePasswordFieldSet.java
+++ b/src/main/java/com/siftscience/model/UpdatePasswordFieldSet.java
@@ -10,7 +10,7 @@ public class UpdatePasswordFieldSet extends BaseAppBrowserSiteBrandFieldSet<Upda
 
     @Expose @SerializedName("$reason") private String reason;
     @Expose @SerializedName("$status") private String status;
-    @Expose @SerializedName("$user_email") private String userEmail;
+    @Expose @SerializedName(USER_EMAIL) private String userEmail;
     @Expose @SerializedName(VERIFICATION_PHONE_NUMBER) private String verificationPhoneNumber;
 
     @Override

--- a/src/test/java/com/siftscience/AddItemToCartEventTest.java
+++ b/src/test/java/com/siftscience/AddItemToCartEventTest.java
@@ -1,6 +1,7 @@
 package com.siftscience;
 
 import com.siftscience.model.AddItemToCartFieldSet;
+import com.siftscience.model.EventResponseBody;
 import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -34,6 +35,7 @@ public class AddItemToCartEventTest {
             "    \"$color\"          : \"Texas Tea\",\n" +
             "    \"$quantity\"       : 2\n" +
             "  },\n" +
+            "  \"$user_email\" : \"billy_jones_301@email.com\",\n" +
             "  \"$verification_phone_number\" : \"+12345678901\"\n" +
             "}";
 
@@ -57,13 +59,14 @@ public class AddItemToCartEventTest {
                 .build());
 
         // Build and execute the request against the mock server.
-        SiftRequest request = client.buildRequest(new AddItemToCartFieldSet()
+        SiftRequest<EventResponse> request = client.buildRequest(new AddItemToCartFieldSet()
             .setUserId("billy_jones_301")
             .setSessionId("gigtleqddo84l8cm15qe4il")
             .setItem(TestUtils.sampleItem2())
+            .setUserEmail("billy_jones_301@email.com")
             .setVerificationPhoneNumber("+12345678901"));
 
-        SiftResponse siftResponse = request.send();
+        SiftResponse<EventResponseBody> siftResponse = request.send();
 
         // Verify the request.
         RecordedRequest request1 = server.takeRequest();
@@ -74,6 +77,7 @@ public class AddItemToCartEventTest {
         // Verify the response.
         Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
         Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
+        Assert.assertNotNull(response.getBody());
         JSONAssert.assertEquals(response.getBody().readUtf8(),
             siftResponse.getBody().toJson(), true);
 

--- a/src/test/java/com/siftscience/AddItemToCartEventTest.java
+++ b/src/test/java/com/siftscience/AddItemToCartEventTest.java
@@ -76,8 +76,8 @@ public class AddItemToCartEventTest {
 
         // Verify the response.
         Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
+        Assert.assertNotNull(siftResponse.getBody());
         Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
-        Assert.assertNotNull(response.getBody());
         JSONAssert.assertEquals(response.getBody().readUtf8(),
             siftResponse.getBody().toJson(), true);
 

--- a/src/test/java/com/siftscience/AddPromotionEventTest.java
+++ b/src/test/java/com/siftscience/AddPromotionEventTest.java
@@ -79,8 +79,8 @@ public class AddPromotionEventTest {
 
         // Verify the response.
         Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
+        Assert.assertNotNull(siftResponse.getBody());
         Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
-        Assert.assertNotNull(response.getBody());
         JSONAssert.assertEquals(response.getBody().readUtf8(),
                 siftResponse.getBody().toJson(), true);
 

--- a/src/test/java/com/siftscience/AddPromotionEventTest.java
+++ b/src/test/java/com/siftscience/AddPromotionEventTest.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.siftscience.model.AddPromotionFieldSet;
+import com.siftscience.model.EventResponseBody;
 import com.siftscience.model.Promotion;
 import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockResponse;
@@ -34,6 +35,7 @@ public class AddPromotionEventTest {
                 "      }\n" +
                 "    }\n" +
                 "  ],\n" +
+                "  \"$user_email\" : \"billy_jones_301@email.com\",\n" +
                 "  \"$verification_phone_number\" : \"+12345678901\"\n" +
                 "}";
 
@@ -61,12 +63,13 @@ public class AddPromotionEventTest {
         promotions.add(TestUtils.samplePromotion3());
 
         // Build and execute the request against the mock server.
-        SiftRequest request = client.buildRequest(new AddPromotionFieldSet()
+        SiftRequest<EventResponse> request = client.buildRequest(new AddPromotionFieldSet()
                 .setUserId("billy_jones_301")
                 .setPromotions(promotions)
+                .setUserEmail("billy_jones_301@email.com")
                 .setVerificationPhoneNumber("+12345678901"));
 
-        SiftResponse siftResponse = request.send();
+        SiftResponse<EventResponseBody> siftResponse = request.send();
 
         // Verify the request.
         RecordedRequest request1 = server.takeRequest();
@@ -77,6 +80,7 @@ public class AddPromotionEventTest {
         // Verify the response.
         Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
         Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
+        Assert.assertNotNull(response.getBody());
         JSONAssert.assertEquals(response.getBody().readUtf8(),
                 siftResponse.getBody().toJson(), true);
 

--- a/src/test/java/com/siftscience/ContentStatusEventTest.java
+++ b/src/test/java/com/siftscience/ContentStatusEventTest.java
@@ -63,8 +63,8 @@ public class ContentStatusEventTest {
 
         // Verify the response.
         Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
+        Assert.assertNotNull(siftResponse.getBody());
         Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
-        Assert.assertNotNull(response.getBody());
         JSONAssert.assertEquals(response.getBody().readUtf8(),
                 siftResponse.getBody().toJson(), true);
 

--- a/src/test/java/com/siftscience/ContentStatusEventTest.java
+++ b/src/test/java/com/siftscience/ContentStatusEventTest.java
@@ -3,6 +3,7 @@ package com.siftscience;
 import static java.net.HttpURLConnection.HTTP_OK;
 
 import com.siftscience.model.ContentStatusFieldSet;
+import com.siftscience.model.EventResponseBody;
 import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -20,6 +21,7 @@ public class ContentStatusEventTest {
                 "  \"$user_id\"    : \"billy_jones_301\",\n" +
                 "  \"$content_id\" : \"9671500641\",\n" +
                 "  \"$status\"     : \"$paused\",\n" +
+                "  \"$user_email\" : \"billy_jones_301@email.com\",\n" +
                 "  \"$verification_phone_number\" : \"+12345678901\"\n" +
                 "}";
 
@@ -44,13 +46,14 @@ public class ContentStatusEventTest {
                 .build());
 
         // Build and execute the request against the mock server.
-        SiftRequest request = client.buildRequest(new ContentStatusFieldSet()
+        SiftRequest<EventResponse> request = client.buildRequest(new ContentStatusFieldSet()
                 .setUserId("billy_jones_301")
                 .setContentId("9671500641")
                 .setStatus("$paused")
+                .setUserEmail("billy_jones_301@email.com")
                 .setVerificationPhoneNumber("+12345678901"));
 
-        SiftResponse siftResponse = request.send();
+        SiftResponse<EventResponseBody> siftResponse = request.send();
 
         // Verify the request.
         RecordedRequest request1 = server.takeRequest();
@@ -61,6 +64,7 @@ public class ContentStatusEventTest {
         // Verify the response.
         Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
         Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
+        Assert.assertNotNull(response.getBody());
         JSONAssert.assertEquals(response.getBody().readUtf8(),
                 siftResponse.getBody().toJson(), true);
 

--- a/src/test/java/com/siftscience/CreateOrderEventTest.java
+++ b/src/test/java/com/siftscience/CreateOrderEventTest.java
@@ -68,8 +68,8 @@ public class CreateOrderEventTest {
             "  },\n" +
             "  \"$expedited_shipping\" : true,\n" +
             "  \"$shipping_method\"    : \"$physical\",\n" +
-            "  \"shipping_carrier\"    : \"The Best Carrier\",\n" +
-            "  \"shipping_tracking_numbers\" : [\"track-1\", \"track-2\"],\n" +
+            "  \"$shipping_carrier\"    : \"The Best Carrier\",\n" +
+            "  \"$shipping_tracking_numbers\" : [\"track-1\", \"track-2\"],\n" +
             "  \"$bookings\": [\n" +
             "    {\n" +
             "      \"$booking_type\": \"$flight\",\n" +
@@ -273,8 +273,8 @@ public class CreateOrderEventTest {
                 "  },\n" +
                 "  \"$expedited_shipping\" : true,\n" +
                 "  \"$shipping_method\"    : \"$physical\",\n" +
-                "  \"shipping_carrier\"    : \"The Best Carrier\",\n" +
-                "  \"shipping_tracking_numbers\" : [\"track-1\", \"track-2\"],\n" +
+                "  \"$shipping_carrier\"    : \"The Best Carrier\",\n" +
+                "  \"$shipping_tracking_numbers\" : [\"track-1\", \"track-2\"],\n" +
                 "  \"$items\"             : [\n" +
                 "    {\n" +
                 "      \"$item_id\"        : \"12344321\",\n" +
@@ -448,8 +448,8 @@ public class CreateOrderEventTest {
             "  },\n" +
             "  \"$expedited_shipping\": true,\n" +
             "  \"$shipping_method\": \"$physical\",\n" +
-            "  \"shipping_carrier\"    : \"The Best Carrier\",\n" +
-            "  \"shipping_tracking_numbers\" : [\"track-1\", \"track-2\"],\n" +
+            "  \"$shipping_carrier\"    : \"The Best Carrier\",\n" +
+            "  \"$shipping_tracking_numbers\" : [\"track-1\", \"track-2\"],\n" +
             "  \"$ordered_from\" : {\n" +
             "    \"$store_id\"      : \"123\",\n" +
             "    \"$store_address\" : {\n" +

--- a/src/test/java/com/siftscience/CreateOrderEventTest.java
+++ b/src/test/java/com/siftscience/CreateOrderEventTest.java
@@ -1,11 +1,13 @@
 package com.siftscience;
 
+import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_OK;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import com.siftscience.exception.InvalidFieldException;
 import com.siftscience.model.Booking;
 import com.siftscience.model.CreateOrderFieldSet;
 import com.siftscience.model.DigitalOrder;
@@ -220,10 +222,342 @@ public class CreateOrderEventTest {
 
         // Verify the response.
         Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
+        Assert.assertNotNull(siftResponse.getBody());
         Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
-        Assert.assertNotNull(response.getBody());
         JSONAssert.assertEquals(response.getBody().readUtf8(),
             siftResponse.getBody().toJson(), true);
+
+        server.shutdown();
+    }
+
+    @Test
+    public void testCreateOrderEventWithBookingsShippingCarrierIsNull()
+        throws IOException, InterruptedException {
+
+        // The expected JSON payload of the request.
+        String expectedRequestBody = "{\n" +
+            "  \"$type\"             : \"$create_order\",\n" +
+            "  \"$api_key\"          : \"YOUR_API_KEY\",\n" +
+            "  \"$user_id\"          : \"billy_jones_301\",\n" +
+            "\n" +
+            "  \"$session_id\"       : \"gigtleqddo84l8cm15qe4il\",\n" +
+            "  \"$order_id\"         : \"ORDER-28168441\",\n" +
+            "  \"$user_email\"       : \"bill@gmail.com\",\n" +
+            "  \"$amount\"           : 115940000,\n" +
+            "  \"$currency_code\"    : \"USD\",\n" +
+            "  \"$billing_address\"  : {\n" +
+            "      \"$name\"         : \"Bill Jones\",\n" +
+            "      \"$phone\"        : \"1-415-555-6041\",\n" +
+            "      \"$address_1\"    : \"2100 Main Street\",\n" +
+            "      \"$address_2\"    : \"Apt 3B\",\n" +
+            "      \"$city\"         : \"New London\",\n" +
+            "      \"$region\"       : \"New Hampshire\",\n" +
+            "      \"$country\"      : \"US\",\n" +
+            "      \"$zipcode\"      : \"03257\"\n" +
+            "  },\n" +
+            "  \"$payment_methods\"  : [\n" +
+            "      {\n" +
+            "          \"$payment_type\"    : \"$credit_card\",\n" +
+            "          \"$payment_gateway\" : \"$braintree\",\n" +
+            "          \"$card_bin\"        : \"542486\",\n" +
+            "          \"$card_last4\"      : \"4444\"\n" +
+            "      }\n" +
+            "  ],\n" +
+            "  \"$shipping_address\"  : {\n" +
+            "      \"$name\"          : \"Bill Jones\",\n" +
+            "      \"$phone\"         : \"1-415-555-6041\",\n" +
+            "      \"$address_1\"     : \"2100 Main Street\",\n" +
+            "      \"$address_2\"     : \"Apt 3B\",\n" +
+            "      \"$city\"          : \"New London\",\n" +
+            "      \"$region\"        : \"New Hampshire\",\n" +
+            "      \"$country\"       : \"US\",\n" +
+            "      \"$zipcode\"       : \"03257\"\n" +
+            "  },\n" +
+            "  \"$expedited_shipping\" : true,\n" +
+            "  \"$shipping_method\"    : \"$physical\",\n" +
+            "  \"$shipping_carrier\"    : null,\n" +
+            "  \"$shipping_tracking_numbers\" : [\"track-1\", \"track-2\"],\n" +
+            "  \"$bookings\": [\n" +
+            "    {\n" +
+            "      \"$booking_type\": \"$flight\",\n" +
+            "      \"$title\": \"SFO - LAS, 2 Adults\",\n" +
+            "      \"$start_time\": 12038412903,\n" +
+            "      \"$end_time\": 12048412903,\n" +
+            "      \"$guests\": [\n" +
+            "        {\n" +
+            "          \"$name\": \"John Doe\",\n" +
+            "          \"$birth_date\": \"1985-01-19\",\n" +
+            "          \"$loyalty_program\": \"skymiles\",\n" +
+            "          \"$loyalty_program_id\": \"PSOV34DF\",\n" +
+            "          \"$phone\": \"1-415-555-6040\",\n" +
+            "          \"$email\": \"jdoe@domain.com\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"$name\": \"Jane Doe\"\n" +
+            "        }\n" +
+            "      ],\n" +
+            "      \"$segments\": [\n" +
+            "        {\n" +
+            "          \"$departure_address\":\n" +
+            "          {\n" +
+            "            \"$name\": \"Bill Jones\",\n" +
+            "            \"$phone\": \"1-415-555-6040\",\n" +
+            "            \"$address_1\": \"2100 Main Street\",\n" +
+            "            \"$address_2\": \"Apt 3B\",\n" +
+            "            \"$city\": \"New London\",\n" +
+            "            \"$region\": \"New Hampshire\",\n" +
+            "            \"$country\": \"US\",\n" +
+            "            \"$zipcode\": \"03257\"\n" +
+            "          },\n" +
+            "          \"$arrival_address\":\n" +
+            "          {\n" +
+            "            \"$name\": \"Bill Jones\",\n" +
+            "            \"$phone\": \"1-415-555-6041\",\n" +
+            "            \"$address_1\": \"2100 Main Street\",\n" +
+            "            \"$address_2\": \"Apt 3B\",\n" +
+            "            \"$city\": \"New London\",\n" +
+            "            \"$region\": \"New Hampshire\",\n" +
+            "            \"$country\": \"US\",\n" +
+            "            \"$zipcode\": \"03257\"\n" +
+            "          },\n" +
+            "          \"$start_time\": 2190121220,\n" +
+            "          \"$end_time\": 2290122129,\n" +
+            "          \"$vessel_number\": \"LH454\",\n" +
+            "          \"$fare_class\": \"Premium Economy\",\n" +
+            "          \"$departure_airport_code\": \"SFO\",\n" +
+            "          \"$arrival_airport_code\": \"LAS\"\n" +
+            "        }\n" +
+            "      ],\n" +
+            "      \"$price\": 49900000,\n" +
+            "      \"$currency_code\": \"USD\",\n" +
+            "      \"$quantity\": 1,\n" +
+            "      \"$tags\": [\n" +
+            "        \"team-123\",\n" +
+            "        \"region-123\"\n" +
+            "      ]\n" +
+            "    }\n" +
+            "  ],\n" +
+            "\n" +
+            "}";
+
+        // Start a new mock server and enqueue a mock response.
+        MockWebServer server = new MockWebServer();
+        MockResponse response = new MockResponse();
+        response.setResponseCode(HTTP_BAD_REQUEST);
+        response.setBody("{\n" +
+            "    \"status\" : 53,\n" +
+            "    \"error_message\" : \"Invalid field value(s) for fields: $.$shipping_carrier, $.$shipping_tracking_numbers. Please check the documentation for valid field values.\",\n" +
+            "    \"time\" : 1327604222,\n" +
+            "    \"request\" : \"" + TestUtils.unescapeJson(expectedRequestBody) + "\"\n" +
+            "}");
+        server.enqueue(response);
+        server.start();
+
+        // Create a new client and link it to the mock server.
+        SiftClient client = new SiftClient("YOUR_API_KEY", "YOUR_ACCOUNT_ID",
+            new OkHttpClient.Builder()
+                .addInterceptor(OkHttpUtils.urlRewritingInterceptor(server))
+                .build());
+
+        // Build the request body.
+        // Payment methods.
+        List<PaymentMethod> paymentMethodList = new ArrayList<>();
+        paymentMethodList.add(TestUtils.samplePaymentMethod1());
+
+        // Bookings
+        List<Booking> bookingList = new ArrayList<>();
+        bookingList.add(TestUtils.sampleBooking());
+
+        // Build and execute the request against the mock server.
+        EventRequest request = client.buildRequest(
+            new CreateOrderFieldSet()
+                .setUserId("billy_jones_301")
+                .setSessionId("gigtleqddo84l8cm15qe4il")
+                .setOrderId("ORDER-28168441")
+                .setUserEmail("bill@gmail.com")
+                .setAmount(115940000L)
+                .setCurrencyCode("USD")
+                .setBillingAddress(TestUtils.sampleAddress2())
+                .setPaymentMethods(paymentMethodList)
+                .setShippingAddress(TestUtils.sampleAddress2())
+                .setExpeditedShipping(true)
+                .setShippingMethod("$physical")
+                .setShippingCarrier(null)
+                .setShippingTrackingNumbers(Arrays.asList("track-1", "track-2"))
+                .setBookings(bookingList));
+
+        Assert.assertThrows(InvalidFieldException.class, request::send);
+
+        // Verify the request.
+        RecordedRequest request1 = server.takeRequest();
+        Assert.assertEquals("POST", request1.getMethod());
+        Assert.assertEquals("/v205/events", request1.getPath());
+
+        server.shutdown();
+    }
+
+    @Test
+    public void testCreateOrderEventWithBookingsShippingTrackingNumberIsNull()
+        throws IOException, InterruptedException {
+
+        // The expected JSON payload of the request.
+        String expectedRequestBody = "{\n" +
+            "  \"$type\"             : \"$create_order\",\n" +
+            "  \"$api_key\"          : \"YOUR_API_KEY\",\n" +
+            "  \"$user_id\"          : \"billy_jones_301\",\n" +
+            "\n" +
+            "  \"$session_id\"       : \"gigtleqddo84l8cm15qe4il\",\n" +
+            "  \"$order_id\"         : \"ORDER-28168441\",\n" +
+            "  \"$user_email\"       : \"bill@gmail.com\",\n" +
+            "  \"$amount\"           : 115940000,\n" +
+            "  \"$currency_code\"    : \"USD\",\n" +
+            "  \"$billing_address\"  : {\n" +
+            "      \"$name\"         : \"Bill Jones\",\n" +
+            "      \"$phone\"        : \"1-415-555-6041\",\n" +
+            "      \"$address_1\"    : \"2100 Main Street\",\n" +
+            "      \"$address_2\"    : \"Apt 3B\",\n" +
+            "      \"$city\"         : \"New London\",\n" +
+            "      \"$region\"       : \"New Hampshire\",\n" +
+            "      \"$country\"      : \"US\",\n" +
+            "      \"$zipcode\"      : \"03257\"\n" +
+            "  },\n" +
+            "  \"$payment_methods\"  : [\n" +
+            "      {\n" +
+            "          \"$payment_type\"    : \"$credit_card\",\n" +
+            "          \"$payment_gateway\" : \"$braintree\",\n" +
+            "          \"$card_bin\"        : \"542486\",\n" +
+            "          \"$card_last4\"      : \"4444\"\n" +
+            "      }\n" +
+            "  ],\n" +
+            "  \"$shipping_address\"  : {\n" +
+            "      \"$name\"          : \"Bill Jones\",\n" +
+            "      \"$phone\"         : \"1-415-555-6041\",\n" +
+            "      \"$address_1\"     : \"2100 Main Street\",\n" +
+            "      \"$address_2\"     : \"Apt 3B\",\n" +
+            "      \"$city\"          : \"New London\",\n" +
+            "      \"$region\"        : \"New Hampshire\",\n" +
+            "      \"$country\"       : \"US\",\n" +
+            "      \"$zipcode\"       : \"03257\"\n" +
+            "  },\n" +
+            "  \"$expedited_shipping\" : true,\n" +
+            "  \"$shipping_method\"    : \"$physical\",\n" +
+            "  \"$shipping_carrier\"    : \"The Best Carrier\",\n" +
+            "  \"$shipping_tracking_numbers\" : [null],\n" +
+            "  \"$bookings\": [\n" +
+            "    {\n" +
+            "      \"$booking_type\": \"$flight\",\n" +
+            "      \"$title\": \"SFO - LAS, 2 Adults\",\n" +
+            "      \"$start_time\": 12038412903,\n" +
+            "      \"$end_time\": 12048412903,\n" +
+            "      \"$guests\": [\n" +
+            "        {\n" +
+            "          \"$name\": \"John Doe\",\n" +
+            "          \"$birth_date\": \"1985-01-19\",\n" +
+            "          \"$loyalty_program\": \"skymiles\",\n" +
+            "          \"$loyalty_program_id\": \"PSOV34DF\",\n" +
+            "          \"$phone\": \"1-415-555-6040\",\n" +
+            "          \"$email\": \"jdoe@domain.com\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"$name\": \"Jane Doe\"\n" +
+            "        }\n" +
+            "      ],\n" +
+            "      \"$segments\": [\n" +
+            "        {\n" +
+            "          \"$departure_address\":\n" +
+            "          {\n" +
+            "            \"$name\": \"Bill Jones\",\n" +
+            "            \"$phone\": \"1-415-555-6040\",\n" +
+            "            \"$address_1\": \"2100 Main Street\",\n" +
+            "            \"$address_2\": \"Apt 3B\",\n" +
+            "            \"$city\": \"New London\",\n" +
+            "            \"$region\": \"New Hampshire\",\n" +
+            "            \"$country\": \"US\",\n" +
+            "            \"$zipcode\": \"03257\"\n" +
+            "          },\n" +
+            "          \"$arrival_address\":\n" +
+            "          {\n" +
+            "            \"$name\": \"Bill Jones\",\n" +
+            "            \"$phone\": \"1-415-555-6041\",\n" +
+            "            \"$address_1\": \"2100 Main Street\",\n" +
+            "            \"$address_2\": \"Apt 3B\",\n" +
+            "            \"$city\": \"New London\",\n" +
+            "            \"$region\": \"New Hampshire\",\n" +
+            "            \"$country\": \"US\",\n" +
+            "            \"$zipcode\": \"03257\"\n" +
+            "          },\n" +
+            "          \"$start_time\": 2190121220,\n" +
+            "          \"$end_time\": 2290122129,\n" +
+            "          \"$vessel_number\": \"LH454\",\n" +
+            "          \"$fare_class\": \"Premium Economy\",\n" +
+            "          \"$departure_airport_code\": \"SFO\",\n" +
+            "          \"$arrival_airport_code\": \"LAS\"\n" +
+            "        }\n" +
+            "      ],\n" +
+            "      \"$price\": 49900000,\n" +
+            "      \"$currency_code\": \"USD\",\n" +
+            "      \"$quantity\": 1,\n" +
+            "      \"$tags\": [\n" +
+            "        \"team-123\",\n" +
+            "        \"region-123\"\n" +
+            "      ]\n" +
+            "    }\n" +
+            "  ],\n" +
+            "\n" +
+            "}";
+
+        // Start a new mock server and enqueue a mock response.
+        MockWebServer server = new MockWebServer();
+        MockResponse response = new MockResponse();
+        response.setResponseCode(HTTP_BAD_REQUEST);
+        response.setBody("{\n" +
+            "    \"status\" : 53,\n" +
+            "    \"error_message\" : \"Invalid field value(s) for fields: $.$shipping_tracking_numbers[0]. Please check the documentation for valid field values.\",\n" +
+            "    \"time\" : 1327604222,\n" +
+            "    \"request\" : \"" + TestUtils.unescapeJson(expectedRequestBody) + "\"\n" +
+            "}");
+        server.enqueue(response);
+        server.start();
+
+        // Create a new client and link it to the mock server.
+        SiftClient client = new SiftClient("YOUR_API_KEY", "YOUR_ACCOUNT_ID",
+            new OkHttpClient.Builder()
+                .addInterceptor(OkHttpUtils.urlRewritingInterceptor(server))
+                .build());
+
+        // Build the request body.
+        // Payment methods.
+        List<PaymentMethod> paymentMethodList = new ArrayList<>();
+        paymentMethodList.add(TestUtils.samplePaymentMethod1());
+
+        // Bookings
+        List<Booking> bookingList = new ArrayList<>();
+        bookingList.add(TestUtils.sampleBooking());
+
+        // Build and execute the request against the mock server.
+        EventRequest request = client.buildRequest(
+            new CreateOrderFieldSet()
+                .setUserId("billy_jones_301")
+                .setSessionId("gigtleqddo84l8cm15qe4il")
+                .setOrderId("ORDER-28168441")
+                .setUserEmail("bill@gmail.com")
+                .setAmount(115940000L)
+                .setCurrencyCode("USD")
+                .setBillingAddress(TestUtils.sampleAddress2())
+                .setPaymentMethods(paymentMethodList)
+                .setShippingAddress(TestUtils.sampleAddress2())
+                .setExpeditedShipping(true)
+                .setShippingMethod("$physical")
+                .setShippingCarrier("The Best Carrier")
+                .setShippingTrackingNumbers(Arrays.asList((String) null))
+                .setBookings(bookingList));
+
+        Assert.assertThrows(InvalidFieldException.class, request::send);
+
+        // Verify the request.
+        RecordedRequest request1 = server.takeRequest();
+        Assert.assertEquals("POST", request1.getMethod());
+        Assert.assertEquals("/v205/events", request1.getPath());
 
         server.shutdown();
     }
@@ -393,8 +727,8 @@ public class CreateOrderEventTest {
 
         // Verify the response.
         Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
+        Assert.assertNotNull(siftResponse.getBody());
         Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
-        Assert.assertNotNull(response.getBody());
         JSONAssert.assertEquals(response.getBody().readUtf8(),
                 siftResponse.getBody().toJson(), true);
 
@@ -521,8 +855,8 @@ public class CreateOrderEventTest {
 
         // Verify the response.
         Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
+        Assert.assertNotNull(siftResponse.getBody());
         Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
-        Assert.assertNotNull(response.getBody());
         JSONAssert.assertEquals(response.getBody().readUtf8(),
             siftResponse.getBody().toJson(), true);
 

--- a/src/test/java/com/siftscience/CreateOrderEventTest.java
+++ b/src/test/java/com/siftscience/CreateOrderEventTest.java
@@ -3,6 +3,7 @@ package com.siftscience;
 import static java.net.HttpURLConnection.HTTP_OK;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import com.siftscience.model.Booking;
@@ -67,6 +68,8 @@ public class CreateOrderEventTest {
             "  },\n" +
             "  \"$expedited_shipping\" : true,\n" +
             "  \"$shipping_method\"    : \"$physical\",\n" +
+            "  \"shipping_carrier\"    : \"The Best Carrier\",\n" +
+            "  \"shipping_tracking_numbers\" : [\"track-1\", \"track-2\"],\n" +
             "  \"$bookings\": [\n" +
             "    {\n" +
             "      \"$booking_type\": \"$flight\",\n" +
@@ -196,6 +199,8 @@ public class CreateOrderEventTest {
                 .setShippingAddress(TestUtils.sampleAddress2())
                 .setExpeditedShipping(true)
                 .setShippingMethod("$physical")
+                .setShippingCarrier("The Best Carrier")
+                .setShippingTrackingNumbers(Arrays.asList("track-1", "track-2"))
                 .setBookings(bookingList)
                 .setSellerUserId("slinkys_emporium")
                 .setPromotions(promotionList)
@@ -216,6 +221,7 @@ public class CreateOrderEventTest {
         // Verify the response.
         Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
         Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
+        Assert.assertNotNull(response.getBody());
         JSONAssert.assertEquals(response.getBody().readUtf8(),
             siftResponse.getBody().toJson(), true);
 
@@ -267,6 +273,8 @@ public class CreateOrderEventTest {
                 "  },\n" +
                 "  \"$expedited_shipping\" : true,\n" +
                 "  \"$shipping_method\"    : \"$physical\",\n" +
+                "  \"shipping_carrier\"    : \"The Best Carrier\",\n" +
+                "  \"shipping_tracking_numbers\" : [\"track-1\", \"track-2\"],\n" +
                 "  \"$items\"             : [\n" +
                 "    {\n" +
                 "      \"$item_id\"        : \"12344321\",\n" +
@@ -365,6 +373,8 @@ public class CreateOrderEventTest {
                         .setShippingAddress(TestUtils.sampleAddress2())
                         .setExpeditedShipping(true)
                         .setShippingMethod("$physical")
+                        .setShippingCarrier("The Best Carrier")
+                        .setShippingTrackingNumbers(Arrays.asList("track-1", "track-2"))
                         .setItems(itemList)
                         .setSellerUserId("slinkys_emporium")
                         .setPromotions(promotionList)
@@ -384,6 +394,7 @@ public class CreateOrderEventTest {
         // Verify the response.
         Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
         Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
+        Assert.assertNotNull(response.getBody());
         JSONAssert.assertEquals(response.getBody().readUtf8(),
                 siftResponse.getBody().toJson(), true);
 
@@ -437,6 +448,8 @@ public class CreateOrderEventTest {
             "  },\n" +
             "  \"$expedited_shipping\": true,\n" +
             "  \"$shipping_method\": \"$physical\",\n" +
+            "  \"shipping_carrier\"    : \"The Best Carrier\",\n" +
+            "  \"shipping_tracking_numbers\" : [\"track-1\", \"track-2\"],\n" +
             "  \"$ordered_from\" : {\n" +
             "    \"$store_id\"      : \"123\",\n" +
             "    \"$store_address\" : {\n" +
@@ -494,6 +507,8 @@ public class CreateOrderEventTest {
                 .setShippingAddress(TestUtils.sampleAddress2())
                 .setExpeditedShipping(true)
                 .setShippingMethod("$physical")
+                .setShippingCarrier("The Best Carrier")
+                .setShippingTrackingNumbers(Arrays.asList("track-1", "track-2"))
                 .setVerificationPhoneNumber("+12345678901"));
 
         EventResponse siftResponse = request.send();
@@ -507,6 +522,7 @@ public class CreateOrderEventTest {
         // Verify the response.
         Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
         Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
+        Assert.assertNotNull(response.getBody());
         JSONAssert.assertEquals(response.getBody().readUtf8(),
             siftResponse.getBody().toJson(), true);
 

--- a/src/test/java/com/siftscience/FlagContentEventTest.java
+++ b/src/test/java/com/siftscience/FlagContentEventTest.java
@@ -2,6 +2,7 @@ package com.siftscience;
 
 import static java.net.HttpURLConnection.HTTP_OK;
 
+import com.siftscience.model.EventResponseBody;
 import com.siftscience.model.FlagContentFieldSet;
 import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockResponse;
@@ -20,7 +21,9 @@ public class FlagContentEventTest {
                 "  \"$user_id\"    : \"billy_jones_301\",\n" +
                 "  \"$content_id\" : \"9671500641\",\n" +
                 "\n" +
-                "  \"$flagged_by\" : \"jamieli89\"\n" +
+                "  \"$flagged_by\" : \"jamieli89\",\n" +
+                "  \"$user_email\" : \"billy_jones_301@email.com\",\n" +
+                "  \"$verification_phone_number\" : \"+12345678901\"\n" +
                 "}";
 
 
@@ -44,12 +47,14 @@ public class FlagContentEventTest {
                 .build());
 
         // Build and execute the request against the mock server.
-        SiftRequest request = client.buildRequest(new FlagContentFieldSet()
+        SiftRequest<EventResponse> request = client.buildRequest(new FlagContentFieldSet()
                 .setUserId("billy_jones_301")
                 .setContentId("9671500641")
-                .setFlaggedBy("jamieli89"));
+                .setFlaggedBy("jamieli89")
+                .setUserEmail("billy_jones_301@email.com")
+                .setVerificationPhoneNumber("+12345678901"));
 
-        SiftResponse siftResponse = request.send();
+        SiftResponse<EventResponseBody> siftResponse = request.send();
 
         // Verify the request.
         RecordedRequest request1 = server.takeRequest();
@@ -60,6 +65,7 @@ public class FlagContentEventTest {
         // Verify the response.
         Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
         Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
+        Assert.assertNotNull(response.getBody());
         JSONAssert.assertEquals(response.getBody().readUtf8(),
                 siftResponse.getBody().toJson(), true);
 

--- a/src/test/java/com/siftscience/FlagContentEventTest.java
+++ b/src/test/java/com/siftscience/FlagContentEventTest.java
@@ -66,8 +66,8 @@ public class FlagContentEventTest {
 
         // Verify the response.
         Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
+        Assert.assertNotNull(siftResponse.getBody());
         Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
-        Assert.assertNotNull(response.getBody());
         JSONAssert.assertEquals(response.getBody().readUtf8(),
                 siftResponse.getBody().toJson(), true);
 

--- a/src/test/java/com/siftscience/FlagContentEventTest.java
+++ b/src/test/java/com/siftscience/FlagContentEventTest.java
@@ -22,6 +22,7 @@ public class FlagContentEventTest {
                 "  \"$content_id\" : \"9671500641\",\n" +
                 "\n" +
                 "  \"$flagged_by\" : \"jamieli89\",\n" +
+                "  \"$reason\" : \"$toxic\",\n" +
                 "  \"$user_email\" : \"billy_jones_301@email.com\",\n" +
                 "  \"$verification_phone_number\" : \"+12345678901\"\n" +
                 "}";
@@ -51,6 +52,7 @@ public class FlagContentEventTest {
                 .setUserId("billy_jones_301")
                 .setContentId("9671500641")
                 .setFlaggedBy("jamieli89")
+                .setReason(FlagContentFieldSet.FlagContentReason.TOXIC)
                 .setUserEmail("billy_jones_301@email.com")
                 .setVerificationPhoneNumber("+12345678901"));
 

--- a/src/test/java/com/siftscience/FlagContentEventTest.java
+++ b/src/test/java/com/siftscience/FlagContentEventTest.java
@@ -1,6 +1,9 @@
 package com.siftscience;
 
 import static java.net.HttpURLConnection.HTTP_OK;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 import com.siftscience.model.EventResponseBody;
 import com.siftscience.model.FlagContentFieldSet;
@@ -10,9 +13,28 @@ import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.skyscreamer.jsonassert.JSONAssert;
 
+@RunWith(Parameterized.class)
 public class FlagContentEventTest {
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        FlagContentFieldSet.FlagContentReason[] values = FlagContentFieldSet.FlagContentReason.values();
+        List<Object[]> data = new ArrayList<>(values.length);
+        for (FlagContentFieldSet.FlagContentReason reason : values) {
+            data.add(new Object[] { reason });
+        }
+        return data;
+    }
+
+    private final FlagContentFieldSet.FlagContentReason reason;
+
+    public FlagContentEventTest(FlagContentFieldSet.FlagContentReason reason) {
+        this.reason = reason;
+    }
     @Test
     public void testFlagContent() throws Exception {
         String expectedRequestBody = "{\n" +
@@ -22,7 +44,7 @@ public class FlagContentEventTest {
                 "  \"$content_id\" : \"9671500641\",\n" +
                 "\n" +
                 "  \"$flagged_by\" : \"jamieli89\",\n" +
-                "  \"$reason\" : \"$toxic\",\n" +
+                "  \"$reason\" : \"" + this.reason.value + "\",\n" +
                 "  \"$user_email\" : \"billy_jones_301@email.com\",\n" +
                 "  \"$verification_phone_number\" : \"+12345678901\"\n" +
                 "}";
@@ -52,7 +74,7 @@ public class FlagContentEventTest {
                 .setUserId("billy_jones_301")
                 .setContentId("9671500641")
                 .setFlaggedBy("jamieli89")
-                .setReason(FlagContentFieldSet.FlagContentReason.TOXIC)
+                .setReason(this.reason)
                 .setUserEmail("billy_jones_301@email.com")
                 .setVerificationPhoneNumber("+12345678901"));
 

--- a/src/test/java/com/siftscience/RemoveItemFromCartEventTest.java
+++ b/src/test/java/com/siftscience/RemoveItemFromCartEventTest.java
@@ -2,6 +2,7 @@ package com.siftscience;
 
 import static java.net.HttpURLConnection.HTTP_OK;
 
+import com.siftscience.model.EventResponseBody;
 import com.siftscience.model.RemoveItemFromCartFieldSet;
 import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockResponse;
@@ -33,6 +34,7 @@ public class RemoveItemFromCartEventTest {
                 "    \"$tags\"           : [\"Awesome\", \"Wintertime specials\"],\n" +
                 "    \"$color\"          : \"Texas Tea\"\n" +
                 "  },\n" +
+                "  \"$user_email\" : \"billy_jones_301@email.com\",\n" +
                 "  \"$verification_phone_number\" : \"+12345678901\"\n" +
                 "}";
 
@@ -56,13 +58,14 @@ public class RemoveItemFromCartEventTest {
                 .build());
 
         // Build and execute the request against the mock server.
-        SiftRequest request = client.buildRequest(new RemoveItemFromCartFieldSet()
+        SiftRequest<EventResponse> request = client.buildRequest(new RemoveItemFromCartFieldSet()
                 .setUserId("billy_jones_301")
                 .setSessionId("gigtleqddo84l8cm15qe4il")
                 .setItem(TestUtils.sampleItem2())
+                .setUserEmail("billy_jones_301@email.com")
                 .setVerificationPhoneNumber("+12345678901"));
 
-        SiftResponse siftResponse = request.send();
+        SiftResponse<EventResponseBody> siftResponse = request.send();
 
         // Verify the request.
         RecordedRequest request1 = server.takeRequest();
@@ -73,6 +76,7 @@ public class RemoveItemFromCartEventTest {
         // Verify the response.
         Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
         Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
+        Assert.assertNotNull(response.getBody());
         JSONAssert.assertEquals(response.getBody().readUtf8(),
                 siftResponse.getBody().toJson(), true);
 

--- a/src/test/java/com/siftscience/RemoveItemFromCartEventTest.java
+++ b/src/test/java/com/siftscience/RemoveItemFromCartEventTest.java
@@ -75,8 +75,8 @@ public class RemoveItemFromCartEventTest {
 
         // Verify the response.
         Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
+        Assert.assertNotNull(siftResponse.getBody());
         Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
-        Assert.assertNotNull(response.getBody());
         JSONAssert.assertEquals(response.getBody().readUtf8(),
                 siftResponse.getBody().toJson(), true);
 

--- a/src/test/java/com/siftscience/SiftRequestTest.java
+++ b/src/test/java/com/siftscience/SiftRequestTest.java
@@ -37,7 +37,7 @@ public class SiftRequestTest {
 
         // Verify the request.
         RecordedRequest recordedRequest = server.takeRequest();
-        Assert.assertEquals("SiftScience/v205 sift-java/3.8.0", recordedRequest.getHeader("User-Agent"));
+        Assert.assertEquals("SiftScience/v205 sift-java/3.11.0", recordedRequest.getHeader("User-Agent"));
     }
 
 }

--- a/src/test/java/com/siftscience/UpdateOrderEventTest.java
+++ b/src/test/java/com/siftscience/UpdateOrderEventTest.java
@@ -69,8 +69,8 @@ public class UpdateOrderEventTest {
             "  },\n" +
             "  \"$expedited_shipping\" : true,\n" +
             "  \"$shipping_method\"    : \"$physical\",\n" +
-            "  \"shipping_carrier\"    : \"The Best Carrier\",\n" +
-            "  \"shipping_tracking_numbers\" : [\"track-1\", \"track-2\"],\n" +
+            "  \"$shipping_carrier\"    : \"The Best Carrier\",\n" +
+            "  \"$shipping_tracking_numbers\" : [\"track-1\", \"track-2\"],\n" +
             "  \"$bookings\": [\n" +
             "    {\n" +
             "      \"$booking_type\": \"$flight\",\n" +
@@ -271,8 +271,8 @@ public class UpdateOrderEventTest {
                 "  },\n" +
                 "  \"$expedited_shipping\" : true,\n" +
                 "  \"$shipping_method\"    : \"$physical\",\n" +
-                "  \"shipping_carrier\"    : \"The Best Carrier\",\n" +
-                "  \"shipping_tracking_numbers\" : [\"track-1\", \"track-2\"],\n" +
+                "  \"$shipping_carrier\"    : \"The Best Carrier\",\n" +
+                "  \"$shipping_tracking_numbers\" : [\"track-1\", \"track-2\"],\n" +
                 "  \"$items\"             : [\n" +
                 "    {\n" +
                 "      \"$item_id\"        : \"12344321\",\n" +
@@ -445,8 +445,8 @@ public class UpdateOrderEventTest {
             "  },\n" +
             "  \"$expedited_shipping\": true,\n" +
             "  \"$shipping_method\": \"$physical\",\n" +
-            "  \"shipping_carrier\"    : \"The Best Carrier\",\n" +
-            "  \"shipping_tracking_numbers\" : [\"track-1\", \"track-2\"],\n" +
+            "  \"$shipping_carrier\"    : \"The Best Carrier\",\n" +
+            "  \"$shipping_tracking_numbers\" : [\"track-1\", \"track-2\"],\n" +
             "  \"$ordered_from\" : {\n" +
             "    \"$store_id\"      : \"123\",\n" +
             "    \"$store_address\" : {\n" +

--- a/src/test/java/com/siftscience/UpdateOrderEventTest.java
+++ b/src/test/java/com/siftscience/UpdateOrderEventTest.java
@@ -3,10 +3,12 @@ package com.siftscience;
 import static java.net.HttpURLConnection.HTTP_OK;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import com.siftscience.model.Booking;
 import com.siftscience.model.DigitalOrder;
+import com.siftscience.model.EventResponseBody;
 import com.siftscience.model.Item;
 import com.siftscience.model.PaymentMethod;
 import com.siftscience.model.Promotion;
@@ -67,6 +69,8 @@ public class UpdateOrderEventTest {
             "  },\n" +
             "  \"$expedited_shipping\" : true,\n" +
             "  \"$shipping_method\"    : \"$physical\",\n" +
+            "  \"shipping_carrier\"    : \"The Best Carrier\",\n" +
+            "  \"shipping_tracking_numbers\" : [\"track-1\", \"track-2\"],\n" +
             "  \"$bookings\": [\n" +
             "    {\n" +
             "      \"$booking_type\": \"$flight\",\n" +
@@ -182,7 +186,7 @@ public class UpdateOrderEventTest {
         promotionList.add(TestUtils.samplePromotion1());
 
         // Build and execute the request against the mock server.
-        SiftRequest request = client.buildRequest(
+        SiftRequest<EventResponse> request = client.buildRequest(
             new UpdateOrderFieldSet()
                 .setUserId("billy_jones_301")
                 .setSessionId("gigtleqddo84l8cm15qe4il")
@@ -195,6 +199,8 @@ public class UpdateOrderEventTest {
                 .setShippingAddress(TestUtils.sampleAddress2())
                 .setExpeditedShipping(true)
                 .setShippingMethod("$physical")
+                .setShippingCarrier("The Best Carrier")
+                .setShippingTrackingNumbers(Arrays.asList("track-1", "track-2"))
                 .setBookings(bookingList)
                 .setSellerUserId("slinkys_emporium")
                 .setPromotions(promotionList)
@@ -203,7 +209,7 @@ public class UpdateOrderEventTest {
                 .setCustomField("shipping_choice", "FedEx Ground Courier")
                 .setCustomField("is_first_time_buyer", false));
 
-        SiftResponse siftResponse = request.send();
+        SiftResponse<EventResponseBody> siftResponse = request.send();
 
         // Verify the request.
         RecordedRequest request1 = server.takeRequest();
@@ -214,6 +220,7 @@ public class UpdateOrderEventTest {
         // Verify the response.
         Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
         Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
+        Assert.assertNotNull(response.getBody());
         JSONAssert.assertEquals(response.getBody().readUtf8(),
             siftResponse.getBody().toJson(), true);
 
@@ -264,6 +271,8 @@ public class UpdateOrderEventTest {
                 "  },\n" +
                 "  \"$expedited_shipping\" : true,\n" +
                 "  \"$shipping_method\"    : \"$physical\",\n" +
+                "  \"shipping_carrier\"    : \"The Best Carrier\",\n" +
+                "  \"shipping_tracking_numbers\" : [\"track-1\", \"track-2\"],\n" +
                 "  \"$items\"             : [\n" +
                 "    {\n" +
                 "      \"$item_id\"        : \"12344321\",\n" +
@@ -349,7 +358,7 @@ public class UpdateOrderEventTest {
 
 
         // Build and execute the request against the mock server.
-        SiftRequest request = client.buildRequest(
+        SiftRequest<EventResponse> request = client.buildRequest(
                 new UpdateOrderFieldSet()
                         .setUserId("billy_jones_301")
                         .setSessionId("gigtleqddo84l8cm15qe4il")
@@ -362,6 +371,8 @@ public class UpdateOrderEventTest {
                         .setShippingAddress(TestUtils.sampleAddress2())
                         .setExpeditedShipping(true)
                         .setShippingMethod("$physical")
+                        .setShippingCarrier("The Best Carrier")
+                        .setShippingTrackingNumbers(Arrays.asList("track-1", "track-2"))
                         .setItems(itemList)
                         .setSellerUserId("slinkys_emporium")
                         .setPromotions(promotionList)
@@ -369,7 +380,7 @@ public class UpdateOrderEventTest {
                         .setCustomField("coupon_code", "dollarMadness")
                         .setCustomField("shipping_choice", "FedEx Ground Courier")
                         .setCustomField("is_first_time_buyer", false));
-        SiftResponse siftResponse = request.send();
+        SiftResponse<EventResponseBody> siftResponse = request.send();
 
         // Verify the request.
         RecordedRequest request1 = server.takeRequest();
@@ -380,6 +391,7 @@ public class UpdateOrderEventTest {
         // Verify the response.
         Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
         Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
+        Assert.assertNotNull(response.getBody());
         JSONAssert.assertEquals(response.getBody().readUtf8(),
                 siftResponse.getBody().toJson(), true);
 
@@ -433,6 +445,8 @@ public class UpdateOrderEventTest {
             "  },\n" +
             "  \"$expedited_shipping\": true,\n" +
             "  \"$shipping_method\": \"$physical\",\n" +
+            "  \"shipping_carrier\"    : \"The Best Carrier\",\n" +
+            "  \"shipping_tracking_numbers\" : [\"track-1\", \"track-2\"],\n" +
             "  \"$ordered_from\" : {\n" +
             "    \"$store_id\"      : \"123\",\n" +
             "    \"$store_address\" : {\n" +
@@ -488,7 +502,9 @@ public class UpdateOrderEventTest {
                 .setPaymentMethods(paymentMethodList)
                 .setShippingAddress(TestUtils.sampleAddress2())
                 .setExpeditedShipping(true)
-                .setShippingMethod("$physical"));
+                .setShippingMethod("$physical")
+                .setShippingCarrier("The Best Carrier")
+                .setShippingTrackingNumbers(Arrays.asList("track-1", "track-2")));
 
         EventResponse siftResponse = request.send();
 
@@ -501,6 +517,7 @@ public class UpdateOrderEventTest {
         // Verify the response.
         Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
         Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
+        Assert.assertNotNull(response.getBody());
         JSONAssert.assertEquals(response.getBody().readUtf8(),
             siftResponse.getBody().toJson(), true);
 

--- a/src/test/java/com/siftscience/UpdateOrderEventTest.java
+++ b/src/test/java/com/siftscience/UpdateOrderEventTest.java
@@ -1,11 +1,13 @@
 package com.siftscience;
 
+import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_OK;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import com.siftscience.exception.InvalidFieldException;
 import com.siftscience.model.Booking;
 import com.siftscience.model.DigitalOrder;
 import com.siftscience.model.EventResponseBody;
@@ -219,10 +221,342 @@ public class UpdateOrderEventTest {
 
         // Verify the response.
         Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
+        Assert.assertNotNull(siftResponse.getBody());
         Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
-        Assert.assertNotNull(response.getBody());
         JSONAssert.assertEquals(response.getBody().readUtf8(),
             siftResponse.getBody().toJson(), true);
+
+        server.shutdown();
+    }
+
+    @Test
+    public void testUpdateOrderEventWithBookingsShippingCarrierIsNull() throws IOException,
+        InterruptedException {
+
+        // The expected JSON payload of the request.
+        String expectedRequestBody = "{\n" +
+            "  \"$type\"             : \"$update_order\",\n" +
+            "  \"$api_key\"          : \"YOUR_API_KEY\",\n" +
+            "  \"$user_id\"          : \"billy_jones_301\",\n" +
+            "\n" +
+            "  \"$session_id\"       : \"gigtleqddo84l8cm15qe4il\",\n" +
+            "  \"$order_id\"         : \"ORDER-28168441\",\n" +
+            "  \"$user_email\"       : \"bill@gmail.com\",\n" +
+            "  \"$amount\"           : 115940000,\n" +
+            "  \"$currency_code\"    : \"USD\",\n" +
+            "  \"$billing_address\"  : {\n" +
+            "      \"$name\"         : \"Bill Jones\",\n" +
+            "      \"$phone\"        : \"1-415-555-6041\",\n" +
+            "      \"$address_1\"    : \"2100 Main Street\",\n" +
+            "      \"$address_2\"    : \"Apt 3B\",\n" +
+            "      \"$city\"         : \"New London\",\n" +
+            "      \"$region\"       : \"New Hampshire\",\n" +
+            "      \"$country\"      : \"US\",\n" +
+            "      \"$zipcode\"      : \"03257\"\n" +
+            "  },\n" +
+            "  \"$payment_methods\"  : [\n" +
+            "      {\n" +
+            "          \"$payment_type\"    : \"$credit_card\",\n" +
+            "          \"$payment_gateway\" : \"$braintree\",\n" +
+            "          \"$card_bin\"        : \"542486\",\n" +
+            "          \"$card_last4\"      : \"4444\"\n" +
+            "      }\n" +
+            "  ],\n" +
+            "  \"$shipping_address\"  : {\n" +
+            "      \"$name\"          : \"Bill Jones\",\n" +
+            "      \"$phone\"         : \"1-415-555-6041\",\n" +
+            "      \"$address_1\"     : \"2100 Main Street\",\n" +
+            "      \"$address_2\"     : \"Apt 3B\",\n" +
+            "      \"$city\"          : \"New London\",\n" +
+            "      \"$region\"        : \"New Hampshire\",\n" +
+            "      \"$country\"       : \"US\",\n" +
+            "      \"$zipcode\"       : \"03257\"\n" +
+            "  },\n" +
+            "  \"$expedited_shipping\" : true,\n" +
+            "  \"$shipping_method\"    : \"$physical\",\n" +
+            "  \"$shipping_carrier\"    : null,\n" +
+            "  \"$shipping_tracking_numbers\" : [\"track-1\", \"track-2\"],\n" +
+            "  \"$bookings\": [\n" +
+            "    {\n" +
+            "      \"$booking_type\": \"$flight\",\n" +
+            "      \"$title\": \"SFO - LAS, 2 Adults\",\n" +
+            "      \"$start_time\": 12038412903,\n" +
+            "      \"$end_time\": 12048412903,\n" +
+            "      \"$guests\": [\n" +
+            "        {\n" +
+            "          \"$name\": \"John Doe\",\n" +
+            "          \"$birth_date\": \"1985-01-19\",\n" +
+            "          \"$loyalty_program\": \"skymiles\",\n" +
+            "          \"$loyalty_program_id\": \"PSOV34DF\",\n" +
+            "          \"$phone\": \"1-415-555-6040\",\n" +
+            "          \"$email\": \"jdoe@domain.com\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"$name\": \"Jane Doe\"\n" +
+            "        }\n" +
+            "      ],\n" +
+            "      \"$segments\": [\n" +
+            "        {\n" +
+            "          \"$departure_address\":\n" +
+            "          {\n" +
+            "            \"$name\": \"Bill Jones\",\n" +
+            "            \"$phone\": \"1-415-555-6040\",\n" +
+            "            \"$address_1\": \"2100 Main Street\",\n" +
+            "            \"$address_2\": \"Apt 3B\",\n" +
+            "            \"$city\": \"New London\",\n" +
+            "            \"$region\": \"New Hampshire\",\n" +
+            "            \"$country\": \"US\",\n" +
+            "            \"$zipcode\": \"03257\"\n" +
+            "          },\n" +
+            "          \"$arrival_address\":\n" +
+            "          {\n" +
+            "            \"$name\": \"Bill Jones\",\n" +
+            "            \"$phone\": \"1-415-555-6041\",\n" +
+            "            \"$address_1\": \"2100 Main Street\",\n" +
+            "            \"$address_2\": \"Apt 3B\",\n" +
+            "            \"$city\": \"New London\",\n" +
+            "            \"$region\": \"New Hampshire\",\n" +
+            "            \"$country\": \"US\",\n" +
+            "            \"$zipcode\": \"03257\"\n" +
+            "          },\n" +
+            "          \"$start_time\": 2190121220,\n" +
+            "          \"$end_time\": 2290122129,\n" +
+            "          \"$vessel_number\": \"LH454\",\n" +
+            "          \"$fare_class\": \"Premium Economy\",\n" +
+            "          \"$departure_airport_code\": \"SFO\",\n" +
+            "          \"$arrival_airport_code\": \"LAS\"\n" +
+            "        }\n" +
+            "      ],\n" +
+            "      \"$price\": 49900000,\n" +
+            "      \"$currency_code\": \"USD\",\n" +
+            "      \"$quantity\": 1,\n" +
+            "      \"$tags\": [\n" +
+            "        \"team-123\",\n" +
+            "        \"region-123\"\n" +
+            "      ]\n" +
+            "    }\n" +
+            "  ],\n" +
+            "\n" +
+            "}";
+
+        // Start a new mock server and enqueue a mock response.
+        MockWebServer server = new MockWebServer();
+        MockResponse response = new MockResponse();
+        response.setResponseCode(HTTP_BAD_REQUEST);
+        response.setBody("{\n" +
+            "    \"status\" : 53,\n" +
+            "    \"error_message\" : \"Invalid field value(s) for fields: $.$shipping_carrier, $.$shipping_tracking_numbers. Please check the documentation for valid field values.\",\n" +
+            "    \"time\" : 1327604222,\n" +
+            "    \"request\" : \"" + TestUtils.unescapeJson(expectedRequestBody) + "\"\n" +
+            "}");
+        server.enqueue(response);
+        server.start();
+
+        // Create a new client and link it to the mock server.
+        SiftClient client = new SiftClient("YOUR_API_KEY", "YOUR_ACCOUNT_ID",
+            new OkHttpClient.Builder()
+                .addInterceptor(OkHttpUtils.urlRewritingInterceptor(server))
+                .build());
+
+        // Build the request body.
+        // Payment methods.
+        List<PaymentMethod> paymentMethodList = new ArrayList<>();
+        paymentMethodList.add(TestUtils.samplePaymentMethod1());
+
+        // Bookings
+        List<Booking> bookingList = new ArrayList<>();
+        bookingList.add(TestUtils.sampleBooking());
+
+        // Build and execute the request against the mock server.
+        SiftRequest<EventResponse> request = client.buildRequest(
+            new UpdateOrderFieldSet()
+                .setUserId("billy_jones_301")
+                .setSessionId("gigtleqddo84l8cm15qe4il")
+                .setOrderId("ORDER-28168441")
+                .setUserEmail("bill@gmail.com")
+                .setAmount(115940000L)
+                .setCurrencyCode("USD")
+                .setBillingAddress(TestUtils.sampleAddress2())
+                .setPaymentMethods(paymentMethodList)
+                .setShippingAddress(TestUtils.sampleAddress2())
+                .setExpeditedShipping(true)
+                .setShippingMethod("$physical")
+                .setShippingCarrier(null)
+                .setShippingTrackingNumbers(Arrays.asList("track-1", "track-2"))
+                .setBookings(bookingList));
+
+        Assert.assertThrows(InvalidFieldException.class, request::send);
+
+        // Verify the request.
+        RecordedRequest request1 = server.takeRequest();
+        Assert.assertEquals("POST", request1.getMethod());
+        Assert.assertEquals("/v205/events", request1.getPath());
+
+        server.shutdown();
+    }
+
+    @Test
+    public void testUpdateOrderEventWithBookingsShippingTrackingNumberIsNull() throws IOException,
+        InterruptedException {
+
+        // The expected JSON payload of the request.
+        String expectedRequestBody = "{\n" +
+            "  \"$type\"             : \"$update_order\",\n" +
+            "  \"$api_key\"          : \"YOUR_API_KEY\",\n" +
+            "  \"$user_id\"          : \"billy_jones_301\",\n" +
+            "\n" +
+            "  \"$session_id\"       : \"gigtleqddo84l8cm15qe4il\",\n" +
+            "  \"$order_id\"         : \"ORDER-28168441\",\n" +
+            "  \"$user_email\"       : \"bill@gmail.com\",\n" +
+            "  \"$amount\"           : 115940000,\n" +
+            "  \"$currency_code\"    : \"USD\",\n" +
+            "  \"$billing_address\"  : {\n" +
+            "      \"$name\"         : \"Bill Jones\",\n" +
+            "      \"$phone\"        : \"1-415-555-6041\",\n" +
+            "      \"$address_1\"    : \"2100 Main Street\",\n" +
+            "      \"$address_2\"    : \"Apt 3B\",\n" +
+            "      \"$city\"         : \"New London\",\n" +
+            "      \"$region\"       : \"New Hampshire\",\n" +
+            "      \"$country\"      : \"US\",\n" +
+            "      \"$zipcode\"      : \"03257\"\n" +
+            "  },\n" +
+            "  \"$payment_methods\"  : [\n" +
+            "      {\n" +
+            "          \"$payment_type\"    : \"$credit_card\",\n" +
+            "          \"$payment_gateway\" : \"$braintree\",\n" +
+            "          \"$card_bin\"        : \"542486\",\n" +
+            "          \"$card_last4\"      : \"4444\"\n" +
+            "      }\n" +
+            "  ],\n" +
+            "  \"$shipping_address\"  : {\n" +
+            "      \"$name\"          : \"Bill Jones\",\n" +
+            "      \"$phone\"         : \"1-415-555-6041\",\n" +
+            "      \"$address_1\"     : \"2100 Main Street\",\n" +
+            "      \"$address_2\"     : \"Apt 3B\",\n" +
+            "      \"$city\"          : \"New London\",\n" +
+            "      \"$region\"        : \"New Hampshire\",\n" +
+            "      \"$country\"       : \"US\",\n" +
+            "      \"$zipcode\"       : \"03257\"\n" +
+            "  },\n" +
+            "  \"$expedited_shipping\" : true,\n" +
+            "  \"$shipping_method\"    : \"$physical\",\n" +
+            "  \"$shipping_carrier\"    : \"The Best Carrier\",\n" +
+            "  \"$shipping_tracking_numbers\" : [null],\n" +
+            "  \"$bookings\": [\n" +
+            "    {\n" +
+            "      \"$booking_type\": \"$flight\",\n" +
+            "      \"$title\": \"SFO - LAS, 2 Adults\",\n" +
+            "      \"$start_time\": 12038412903,\n" +
+            "      \"$end_time\": 12048412903,\n" +
+            "      \"$guests\": [\n" +
+            "        {\n" +
+            "          \"$name\": \"John Doe\",\n" +
+            "          \"$birth_date\": \"1985-01-19\",\n" +
+            "          \"$loyalty_program\": \"skymiles\",\n" +
+            "          \"$loyalty_program_id\": \"PSOV34DF\",\n" +
+            "          \"$phone\": \"1-415-555-6040\",\n" +
+            "          \"$email\": \"jdoe@domain.com\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"$name\": \"Jane Doe\"\n" +
+            "        }\n" +
+            "      ],\n" +
+            "      \"$segments\": [\n" +
+            "        {\n" +
+            "          \"$departure_address\":\n" +
+            "          {\n" +
+            "            \"$name\": \"Bill Jones\",\n" +
+            "            \"$phone\": \"1-415-555-6040\",\n" +
+            "            \"$address_1\": \"2100 Main Street\",\n" +
+            "            \"$address_2\": \"Apt 3B\",\n" +
+            "            \"$city\": \"New London\",\n" +
+            "            \"$region\": \"New Hampshire\",\n" +
+            "            \"$country\": \"US\",\n" +
+            "            \"$zipcode\": \"03257\"\n" +
+            "          },\n" +
+            "          \"$arrival_address\":\n" +
+            "          {\n" +
+            "            \"$name\": \"Bill Jones\",\n" +
+            "            \"$phone\": \"1-415-555-6041\",\n" +
+            "            \"$address_1\": \"2100 Main Street\",\n" +
+            "            \"$address_2\": \"Apt 3B\",\n" +
+            "            \"$city\": \"New London\",\n" +
+            "            \"$region\": \"New Hampshire\",\n" +
+            "            \"$country\": \"US\",\n" +
+            "            \"$zipcode\": \"03257\"\n" +
+            "          },\n" +
+            "          \"$start_time\": 2190121220,\n" +
+            "          \"$end_time\": 2290122129,\n" +
+            "          \"$vessel_number\": \"LH454\",\n" +
+            "          \"$fare_class\": \"Premium Economy\",\n" +
+            "          \"$departure_airport_code\": \"SFO\",\n" +
+            "          \"$arrival_airport_code\": \"LAS\"\n" +
+            "        }\n" +
+            "      ],\n" +
+            "      \"$price\": 49900000,\n" +
+            "      \"$currency_code\": \"USD\",\n" +
+            "      \"$quantity\": 1,\n" +
+            "      \"$tags\": [\n" +
+            "        \"team-123\",\n" +
+            "        \"region-123\"\n" +
+            "      ]\n" +
+            "    }\n" +
+            "  ],\n" +
+            "\n" +
+            "}";
+
+        // Start a new mock server and enqueue a mock response.
+        MockWebServer server = new MockWebServer();
+        MockResponse response = new MockResponse();
+        response.setResponseCode(HTTP_BAD_REQUEST);
+        response.setBody("{\n" +
+            "    \"status\" : 53,\n" +
+            "    \"error_message\" : \"Invalid field value(s) for fields: $.$shipping_tracking_numbers[0]. Please check the documentation for valid field values.\",\n" +
+            "    \"time\" : 1327604222,\n" +
+            "    \"request\" : \"" + TestUtils.unescapeJson(expectedRequestBody) + "\"\n" +
+            "}");
+        server.enqueue(response);
+        server.start();
+
+        // Create a new client and link it to the mock server.
+        SiftClient client = new SiftClient("YOUR_API_KEY", "YOUR_ACCOUNT_ID",
+            new OkHttpClient.Builder()
+                .addInterceptor(OkHttpUtils.urlRewritingInterceptor(server))
+                .build());
+
+        // Build the request body.
+        // Payment methods.
+        List<PaymentMethod> paymentMethodList = new ArrayList<>();
+        paymentMethodList.add(TestUtils.samplePaymentMethod1());
+
+        // Bookings
+        List<Booking> bookingList = new ArrayList<>();
+        bookingList.add(TestUtils.sampleBooking());
+
+        // Build and execute the request against the mock server.
+        SiftRequest<EventResponse> request = client.buildRequest(
+            new UpdateOrderFieldSet()
+                .setUserId("billy_jones_301")
+                .setSessionId("gigtleqddo84l8cm15qe4il")
+                .setOrderId("ORDER-28168441")
+                .setUserEmail("bill@gmail.com")
+                .setAmount(115940000L)
+                .setCurrencyCode("USD")
+                .setBillingAddress(TestUtils.sampleAddress2())
+                .setPaymentMethods(paymentMethodList)
+                .setShippingAddress(TestUtils.sampleAddress2())
+                .setExpeditedShipping(true)
+                .setShippingMethod("$physical")
+                .setShippingCarrier("The Best Carrier")
+                .setShippingTrackingNumbers(Arrays.asList((String) null))
+                .setBookings(bookingList));
+
+        Assert.assertThrows(InvalidFieldException.class, request::send);
+
+        // Verify the request.
+        RecordedRequest request1 = server.takeRequest();
+        Assert.assertEquals("POST", request1.getMethod());
+        Assert.assertEquals("/v205/events", request1.getPath());
 
         server.shutdown();
     }
@@ -390,8 +724,8 @@ public class UpdateOrderEventTest {
 
         // Verify the response.
         Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
+        Assert.assertNotNull(siftResponse.getBody());
         Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
-        Assert.assertNotNull(response.getBody());
         JSONAssert.assertEquals(response.getBody().readUtf8(),
                 siftResponse.getBody().toJson(), true);
 
@@ -516,8 +850,8 @@ public class UpdateOrderEventTest {
 
         // Verify the response.
         Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
+        Assert.assertNotNull(siftResponse.getBody());
         Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
-        Assert.assertNotNull(response.getBody());
         JSONAssert.assertEquals(response.getBody().readUtf8(),
             siftResponse.getBody().toJson(), true);
 

--- a/src/test/java/com/siftscience/UpdatePasswordEventTest.java
+++ b/src/test/java/com/siftscience/UpdatePasswordEventTest.java
@@ -3,6 +3,7 @@ package com.siftscience;
 import static java.net.HttpURLConnection.HTTP_OK;
 
 import com.siftscience.model.App;
+import com.siftscience.model.EventResponseBody;
 import com.siftscience.model.UpdatePasswordFieldSet;
 import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockResponse;
@@ -35,6 +36,8 @@ public class UpdatePasswordEventTest {
                 " \"$reason\" : \"$forced_reset\",\n" +
                 " \"$status\" : \"$success\",\n" +
                 " \"$ip\" : \"128.148.1.135\",\n" +
+                " \"$user_email\" : \"billy_jones_301@email.com\",\n" +
+                " \"$verification_phone_number\" : \"+12345678901\"\n" +
                 "}";
 
         MockWebServer server = new MockWebServer();
@@ -62,6 +65,8 @@ public class UpdatePasswordEventTest {
                 .setReason("$forced_reset")
                 .setStatus("$success")
                 .setIp("128.148.1.135")
+                .setUserEmail("billy_jones_301@email.com")
+                .setVerificationPhoneNumber("+12345678901")
                 .setApp(new App()
                         .setAppName("Calculator")
                         .setAppVersion("3.2.7")
@@ -70,8 +75,8 @@ public class UpdatePasswordEventTest {
                         .setDeviceUniqueId("A3D261E4-DE0A-470B-9E4A-720F3D3D22E6")
                         .setOperatingSystem("iOS"));
 
-        SiftRequest request = client.buildRequest(fieldSet);
-        SiftResponse siftResponse = request.send();
+        SiftRequest<EventResponse> request = client.buildRequest(fieldSet);
+        SiftResponse<EventResponseBody> siftResponse = request.send();
 
         //Verify the request
         RecordedRequest request1 = server.takeRequest();
@@ -82,6 +87,7 @@ public class UpdatePasswordEventTest {
         // Verify the response.
         Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
         Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
+        Assert.assertNotNull(response.getBody());
         JSONAssert.assertEquals(response.getBody().readUtf8(), siftResponse.getBody().toJson(), true);
 
         server.shutdown();

--- a/src/test/java/com/siftscience/UpdatePasswordEventTest.java
+++ b/src/test/java/com/siftscience/UpdatePasswordEventTest.java
@@ -86,8 +86,8 @@ public class UpdatePasswordEventTest {
 
         // Verify the response.
         Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
+        Assert.assertNotNull(siftResponse.getBody());
         Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
-        Assert.assertNotNull(response.getBody());
         JSONAssert.assertEquals(response.getBody().readUtf8(), siftResponse.getBody().toJson(), true);
 
         server.shutdown();


### PR DESCRIPTION
### Purpose
As a result of feature parity comparison [API client libraries: Feature parity](https://sift.atlassian.net/wiki/spaces/RNDTEAM/pages/1971355657/API+client+libraries+Feature+parity) Events API endpoints have fields missed in `sift-java` library.

### Description
- Add support for `$user_email` field to `$add_item_to_cart`, `$add_promotion`, `$content_status`, `$flag_content`, `$remove_item_from_cart` and `$update_password` events
- Add support for `$shipping_carrier` and `$shipping_tracking_numbers` fields to `$create_order` and `$update_order` events
- Add support for `$reason` field to `$flag_content` event

### Testing Plan
- Updated unit tests
- Tested on expr environment using sift-java-integration-app
![image](https://github.com/SiftScience/sift-java/assets/136449990/0ea7be82-1e91-4f8e-b69a-3319bd55324c)

