### PR TITLE
[API-7599] Bumps OktHttp and Okio libs to fix CVE-2023-3635

### DIFF
--- a/CHANGES.MD
+++ b/CHANGES.MD
@@ -1,3 +1,7 @@
+3.13.1 (2024-03-28)
+=================
+- Upgrade OkHttp to [4.12.0](https://square.github.io/okhttp/changelogs/changelog_4x/#version-4120) and Okio to [3.6.0](https://square.github.io/okhttp/changelogs/changelog_4x/#version-4120 ) to fix transitive vulnerability [CVE-2023-3635](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-3635)
+
 3.13.0 (2023-09-19)
 =================
 - Add support for score percentiles in score API

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Java 1.7 or later.
 <dependency>
     <groupId>com.siftscience</groupId>
     <artifactId>sift-java</artifactId>
-    <version>3.13.0</version>
+    <version>3.13.1</version>
 </dependency>
 ```
 ### Gradle
 ```
 dependencies {
-    compile 'com.siftscience:sift-java:3.13.0'
+    compile 'com.siftscience:sift-java:3.13.1'
 }
 ```
 ### Other

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'signing'
 apply plugin: 'java-library-distribution'
 
 group = 'com.siftscience'
-version = '3.13.0'
+version = '3.13.1'
 
 repositories {
     mavenCentral()
@@ -26,8 +26,8 @@ dependencies {
     testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '4.10.0'
     testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: '1.3'
     compile 'com.google.code.gson:gson:2.10'
-    compile 'com.squareup.okhttp3:okhttp:4.10.0'
-    compile 'com.squareup.okio:okio:3.2.0'
+    compile 'com.squareup.okhttp3:okhttp:4.12.0'
+    compile 'com.squareup.okio:okio:3.6.0'
     compile 'commons-codec:commons-codec:1.15'
 }
 

--- a/src/main/java/com/siftscience/Constants.java
+++ b/src/main/java/com/siftscience/Constants.java
@@ -3,6 +3,6 @@ package com.siftscience;
 public class Constants {
 
     public static final String API_VERSION = "v205";
-    public static final String LIB_VERSION = "3.13.0";
+    public static final String LIB_VERSION = "3.13.1";
     public static final String USER_AGENT_HEADER = String.format("SiftScience/%s sift-java/%s", API_VERSION, LIB_VERSION);
 }

--- a/src/test/java/com/siftscience/SiftRequestTest.java
+++ b/src/test/java/com/siftscience/SiftRequestTest.java
@@ -37,7 +37,7 @@ public class SiftRequestTest {
 
         // Verify the request.
         RecordedRequest recordedRequest = server.takeRequest();
-        Assert.assertEquals("SiftScience/v205 sift-java/3.13.0", recordedRequest.getHeader("User-Agent"));
+        Assert.assertEquals("SiftScience/v205 sift-java/3.13.1", recordedRequest.getHeader("User-Agent"));
     }
 
 }


### PR DESCRIPTION
## Purpose
Bumps libs to fix transitive vulnerability came from Okio lib and raised by #99