### PR TITLE
API-7698: Fix possible issue with connection becoming stalled after interrupt during call.execute

### DIFF
--- a/CHANGES.MD
+++ b/CHANGES.MD
@@ -1,3 +1,7 @@
+3.14.2 (2024-05-20)
+=================
+- Fixed bug with okHttp causing SocketTimeoutException
+
 3.14.1 (2024-05-16)
 =================
 - Added support for warnings in Events API

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Java 1.7 or later.
 <dependency>
     <groupId>com.siftscience</groupId>
     <artifactId>sift-java</artifactId>
-    <version>3.14.1</version>
+    <version>3.14.2</version>
 </dependency>
 ```
 ### Gradle
 ```
 dependencies {
-    compile 'com.siftscience:sift-java:3.14.1'
+    compile 'com.siftscience:sift-java:3.14.2'
 }
 ```
 ### Other

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'signing'
 apply plugin: 'java-library-distribution'
 
 group = 'com.siftscience'
-version = '3.14.1'
+version = '3.14.2'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/siftscience/ApplyDecisionRequest.java
+++ b/src/main/java/com/siftscience/ApplyDecisionRequest.java
@@ -3,12 +3,14 @@ package com.siftscience;
 import java.io.IOException;
 
 import com.siftscience.model.ApplyDecisionFieldSet;
-import okhttp3.*;
+import okhttp3.Credentials;
+import okhttp3.HttpUrl;
+import okhttp3.Request;
 
 public class ApplyDecisionRequest extends SiftRequest<ApplyDecisionResponse>{
 
-    ApplyDecisionRequest(HttpUrl baseUrl, String accountId, OkHttpClient okClient, ApplyDecisionFieldSet fields) {
-        super(baseUrl, accountId, okClient, fields);
+    ApplyDecisionRequest(HttpUrl baseUrl, String accountId, HttpClient httpClient, ApplyDecisionFieldSet fields) {
+        super(baseUrl, accountId, httpClient, fields);
     }
 
     @Override

--- a/src/main/java/com/siftscience/Constants.java
+++ b/src/main/java/com/siftscience/Constants.java
@@ -3,6 +3,6 @@ package com.siftscience;
 public class Constants {
 
     public static final String API_VERSION = "v205";
-    public static final String LIB_VERSION = "3.14.1";
+    public static final String LIB_VERSION = "3.14.2";
     public static final String USER_AGENT_HEADER = String.format("SiftScience/%s sift-java/%s", API_VERSION, LIB_VERSION);
 }

--- a/src/main/java/com/siftscience/CreateMerchantRequest.java
+++ b/src/main/java/com/siftscience/CreateMerchantRequest.java
@@ -1,18 +1,17 @@
 package com.siftscience;
 
+import java.io.IOException;
+
+import okhttp3.Credentials;
 import okhttp3.HttpUrl;
-import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-import okhttp3.Credentials;
-
-import java.io.IOException;
 
 
 public class CreateMerchantRequest extends SiftMerchantRequest<CreateMerchantResponse> {
 
-    CreateMerchantRequest(HttpUrl baseUrl, String accountId, OkHttpClient okClient, FieldSet fields) {
-        super(baseUrl, accountId, okClient, fields);
+    CreateMerchantRequest(HttpUrl baseUrl, String accountId, HttpClient httpClient, FieldSet fields) {
+        super(baseUrl, accountId, httpClient, fields);
     }
 
     @Override

--- a/src/main/java/com/siftscience/DecisionStatusRequest.java
+++ b/src/main/java/com/siftscience/DecisionStatusRequest.java
@@ -1,16 +1,18 @@
 package com.siftscience;
 
-import com.siftscience.model.DecisionStatusFieldSet;
-import okhttp3.*;
-
 import java.io.IOException;
 
 import static com.siftscience.model.DecisionStatusFieldSet.ENTITY_CONTENT;
 import static com.siftscience.model.DecisionStatusFieldSet.ENTITY_SESSIONS;
+import com.siftscience.model.DecisionStatusFieldSet;
+import okhttp3.Credentials;
+import okhttp3.HttpUrl;
+import okhttp3.Request;
+import okhttp3.Response;
 
 public class DecisionStatusRequest extends SiftRequest<DecisionStatusResponse> {
-    DecisionStatusRequest(HttpUrl baseUrl, String accountId, OkHttpClient okClient, DecisionStatusFieldSet fields) {
-        super(baseUrl, accountId, okClient, fields);
+    DecisionStatusRequest(HttpUrl baseUrl, String accountId, HttpClient httpClient, DecisionStatusFieldSet fields) {
+        super(baseUrl, accountId, httpClient, fields);
     }
 
     @Override

--- a/src/main/java/com/siftscience/EventRequest.java
+++ b/src/main/java/com/siftscience/EventRequest.java
@@ -22,8 +22,8 @@ public class EventRequest extends SiftRequest<EventResponse> {
     private boolean returnScorePercentiles = false;
     private boolean returnWarnings = false;
 
-    EventRequest(HttpUrl baseUrl, String accountId, OkHttpClient okClient, FieldSet fields) {
-        super(baseUrl, accountId, okClient, fields);
+    EventRequest(HttpUrl baseUrl, String accountId, HttpClient client, FieldSet fields) {
+        super(baseUrl, accountId, client, fields);
         abuseTypes = null;
     }
 

--- a/src/main/java/com/siftscience/GetDecisionsRequest.java
+++ b/src/main/java/com/siftscience/GetDecisionsRequest.java
@@ -1,19 +1,18 @@
 package com.siftscience;
 
-import com.siftscience.model.GetDecisionFieldSet;
-
 import java.io.IOException;
+
+import com.siftscience.model.GetDecisionFieldSet;
 import okhttp3.Credentials;
 import okhttp3.HttpUrl;
-import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 
 
 public class GetDecisionsRequest extends SiftRequest<GetDecisionsResponse> {
 
-    GetDecisionsRequest(HttpUrl baseUrl, String accountId, OkHttpClient okClient, FieldSet fields) {
-        super(baseUrl, accountId, okClient, fields);
+    GetDecisionsRequest(HttpUrl baseUrl, String accountId, HttpClient httpClient, FieldSet fields) {
+        super(baseUrl, accountId, httpClient, fields);
     }
 
     public enum Query {

--- a/src/main/java/com/siftscience/GetMerchantRequest.java
+++ b/src/main/java/com/siftscience/GetMerchantRequest.java
@@ -1,15 +1,18 @@
 package com.siftscience;
 
-import com.siftscience.model.GetMerchantFieldSet;
-import okhttp3.*;
-
 import java.io.IOException;
+
+import com.siftscience.model.GetMerchantFieldSet;
+import okhttp3.Credentials;
+import okhttp3.HttpUrl;
+import okhttp3.Request;
+import okhttp3.Response;
 
 
 public class GetMerchantRequest extends SiftMerchantRequest<GetMerchantResponse> {
 
-    GetMerchantRequest(HttpUrl baseUrl, String accountId, OkHttpClient okClient, FieldSet fields) {
-        super(baseUrl, accountId, okClient, fields);
+    GetMerchantRequest(HttpUrl baseUrl, String accountId, HttpClient httpClient, FieldSet fields) {
+        super(baseUrl, accountId, httpClient, fields);
     }
 
     @Override

--- a/src/main/java/com/siftscience/GetMerchantsRequest.java
+++ b/src/main/java/com/siftscience/GetMerchantsRequest.java
@@ -1,15 +1,18 @@
 package com.siftscience;
 
-import com.siftscience.model.GetMerchantsFieldSet;
-import okhttp3.*;
-
 import java.io.IOException;
+
+import com.siftscience.model.GetMerchantsFieldSet;
+import okhttp3.Credentials;
+import okhttp3.HttpUrl;
+import okhttp3.Request;
+import okhttp3.Response;
 
 
 public class GetMerchantsRequest extends SiftMerchantRequest<GetMerchantsResponse> {
 
-    GetMerchantsRequest(HttpUrl baseUrl, String accountId, OkHttpClient okClient, FieldSet fields) {
-        super(baseUrl, accountId, okClient, fields);
+    GetMerchantsRequest(HttpUrl baseUrl, String accountId, HttpClient httpClient, FieldSet fields) {
+        super(baseUrl, accountId, httpClient, fields);
     }
 
     private static String DEFAULT_BATCH_SIZE = "1000";

--- a/src/main/java/com/siftscience/HttpClient.java
+++ b/src/main/java/com/siftscience/HttpClient.java
@@ -1,0 +1,31 @@
+package com.siftscience;
+
+import java.io.IOException;
+
+import com.siftscience.utils.OkHttpUtils;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public class HttpClient {
+
+    private final OkHttpClient okClient;
+    private boolean enqueueRequests;
+
+    public HttpClient(OkHttpClient okHttpClient) {
+        this.okClient = okHttpClient;
+    }
+
+    public OkHttpClient getOkClient() {
+        return okClient;
+    }
+
+    public Response execute(Request request) throws IOException {
+        return enqueueRequests ? OkHttpUtils.execute(request, okClient) :
+            okClient.newCall(request).execute();
+    }
+
+    public void enqueueRequests() {
+        this.enqueueRequests = true;
+    }
+}

--- a/src/main/java/com/siftscience/LabelRequest.java
+++ b/src/main/java/com/siftscience/LabelRequest.java
@@ -1,19 +1,18 @@
 package com.siftscience;
 
+import java.io.IOException;
+
 import com.siftscience.model.LabelFieldSet;
 import okhttp3.HttpUrl;
-import okhttp3.OkHttpClient;
 import okhttp3.Response;
-
-import java.io.IOException;
 
 /**
  * LabelRequest is the request type for the Sift Labels API.
  * https://siftscience.com/developers/docs/curl/labels-api
  */
 public class LabelRequest extends SiftRequest<LabelResponse> {
-    LabelRequest(HttpUrl baseUrl, String accountId, OkHttpClient okClient, LabelFieldSet fields) {
-        super(baseUrl, accountId, okClient, fields);
+    LabelRequest(HttpUrl baseUrl, String accountId, HttpClient httpClient, LabelFieldSet fields) {
+        super(baseUrl, accountId, httpClient, fields);
     }
 
     @Override

--- a/src/main/java/com/siftscience/ScoreRequest.java
+++ b/src/main/java/com/siftscience/ScoreRequest.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 
 import com.siftscience.model.ScoreFieldSet;
 import okhttp3.HttpUrl;
-import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 
@@ -13,8 +12,8 @@ import okhttp3.Response;
  * https://siftscience.com/developers/docs/curl/score-api
  */
 public class ScoreRequest extends SiftRequest<ScoreResponse> {
-    ScoreRequest(HttpUrl baseUrl, String accountId, OkHttpClient okClient, ScoreFieldSet fields) {
-        super(baseUrl, accountId, okClient, fields);
+    ScoreRequest(HttpUrl baseUrl, String accountId, HttpClient httpClient, ScoreFieldSet fields) {
+        super(baseUrl, accountId, httpClient, fields);
     }
 
     /**

--- a/src/main/java/com/siftscience/SiftClient.java
+++ b/src/main/java/com/siftscience/SiftClient.java
@@ -48,7 +48,7 @@ import okhttp3.OkHttpClient;
 public class SiftClient {
     private final String accountId;
     private final String apiKey;
-    private final OkHttpClient okClient;
+    private final HttpClient httpClient;
     private HttpUrl baseUrl = HttpUrl.parse("https://api.sift.com");
 
     public SiftClient(String apiKey, String accountId) {
@@ -58,7 +58,7 @@ public class SiftClient {
     public SiftClient(String apiKey, String accountId, OkHttpClient okHttpClient) {
         this.apiKey = apiKey;
         this.accountId = accountId;
-        this.okClient = okHttpClient;
+        this.httpClient = new HttpClient(okHttpClient);
     }
 
     /**
@@ -85,84 +85,88 @@ public class SiftClient {
         return accountId;
     }
 
+    public void enqueueRequests() {
+        httpClient.enqueueRequests();
+    }
+
     public EventRequest buildRequest(FieldSet fields) {
         setupApiKey(fields);
-        return new EventRequest(baseUrl, getAccountId(), okClient, fields);
+        return new EventRequest(baseUrl, getAccountId(), httpClient, fields);
     }
 
     public ApplyDecisionRequest buildRequest(ApplyDecisionFieldSet fields) {
         setupApiKey(fields);
-        return new ApplyDecisionRequest(baseUrl, getAccountId(), okClient, fields);
+        return new ApplyDecisionRequest(baseUrl, getAccountId(), httpClient, fields);
     }
 
     public GetDecisionsRequest buildRequest(GetDecisionFieldSet fields) {
         setupApiKey(fields);
-        return new GetDecisionsRequest(baseUrl, getAccountId(), okClient, fields);
+        return new GetDecisionsRequest(baseUrl, getAccountId(), httpClient, fields);
     }
 
     public DecisionStatusRequest buildRequest(DecisionStatusFieldSet fields) {
         setupApiKey(fields);
-        return new DecisionStatusRequest(baseUrl, getAccountId(), okClient, fields);
+        return new DecisionStatusRequest(baseUrl, getAccountId(), httpClient, fields);
     }
 
     public LabelRequest buildRequest(LabelFieldSet fields) {
         setupApiKey(fields);
-        return new LabelRequest(baseUrl, getAccountId(), okClient, fields);
+        return new LabelRequest(baseUrl, getAccountId(), httpClient, fields);
     }
 
     public UnlabelRequest buildRequest(UnlabelFieldSet fields) {
         setupApiKey(fields);
-        return new UnlabelRequest(baseUrl, getAccountId(), okClient, fields);
+        return new UnlabelRequest(baseUrl, getAccountId(), httpClient, fields);
     }
 
     public ScoreRequest buildRequest(ScoreFieldSet fields) {
         setupApiKey(fields);
-        return new ScoreRequest(baseUrl, getAccountId(), okClient, fields);
+        return new ScoreRequest(baseUrl, getAccountId(), httpClient, fields);
     }
 
     public UserScoreRequest buildRequest(UserScoreFieldSet fields) {
         setupApiKey(fields);
-        return new UserScoreRequest(baseUrl, getAccountId(), okClient, fields);
+        return new UserScoreRequest(baseUrl, getAccountId(), httpClient, fields);
     }
 
     public WorkflowStatusRequest buildRequest(WorkflowStatusFieldSet fields) {
         setupApiKey(fields);
-        return new WorkflowStatusRequest(baseUrl, getAccountId(), okClient, fields);
+        return new WorkflowStatusRequest(baseUrl, getAccountId(), httpClient, fields);
     }
 
     public GetMerchantsRequest buildRequest(GetMerchantsFieldSet fields) {
         setupApiKey(fields);
-        return new GetMerchantsRequest(baseUrl, getAccountId(), okClient, fields);
+        return new GetMerchantsRequest(baseUrl, getAccountId(), httpClient, fields);
     }
 
     public GetMerchantRequest buildRequest(GetMerchantFieldSet fields) {
         setupApiKey(fields);
-        return new GetMerchantRequest(baseUrl, getAccountId(), okClient, fields);
+        return new GetMerchantRequest(baseUrl, getAccountId(), httpClient, fields);
     }
 
     public CreateMerchantRequest buildRequest(CreateMerchantFieldSet fields) {
         setupApiKey(fields);
-        return new CreateMerchantRequest(baseUrl, getAccountId(), okClient, fields);
+        return new CreateMerchantRequest(baseUrl, getAccountId(), httpClient, fields);
     }
 
     public UpdateMerchantRequest buildRequest(UpdateMerchantFieldSet fields, String merchantId) {
         setupApiKey(fields);
-        return new UpdateMerchantRequest(baseUrl, getAccountId(), okClient, fields, merchantId);
+        return new UpdateMerchantRequest(baseUrl, getAccountId(), httpClient, fields, merchantId);
     }
 
     public VerificationSendRequest buildRequest(VerificationSendFieldSet fields) {
         setupApiKey(fields);
-        return new VerificationSendRequest(baseUrl, getAccountId(), okClient, fields);
+        return new VerificationSendRequest(baseUrl, getAccountId(), httpClient, fields);
     }
 
     public VerificationResendRequest buildRequest(VerificationResendFieldSet fields) {
         setupApiKey(fields);
-        return new VerificationResendRequest(baseUrl, getAccountId(), okClient, fields);
+        return new VerificationResendRequest(baseUrl, getAccountId(), httpClient, fields);
     }
 
     public VerificationCheckRequest buildRequest(VerificationCheckFieldSet fields) {
         setupApiKey(fields);
-        return new VerificationCheckRequest(baseUrl, getAccountId(), okClient, fields);
+        return new VerificationCheckRequest(baseUrl, getAccountId(), httpClient, fields);
     }
 
     private void setupApiKey(FieldSet fields) {

--- a/src/main/java/com/siftscience/SiftClient.java
+++ b/src/main/java/com/siftscience/SiftClient.java
@@ -72,6 +72,11 @@ public class SiftClient {
         this.baseUrl = baseUrl;
     }
 
+    public SiftClient(String apiKey, String accountId, HttpUrl baseUrl, OkHttpClient okHttpClient) {
+        this(apiKey, accountId, okHttpClient);
+        this.baseUrl = baseUrl;
+    }
+
     public String getApiKey() {
         return apiKey;
     }

--- a/src/main/java/com/siftscience/SiftMerchantRequest.java
+++ b/src/main/java/com/siftscience/SiftMerchantRequest.java
@@ -17,7 +17,7 @@ import static com.siftscience.Constants.USER_AGENT_HEADER;
 public abstract class SiftMerchantRequest<T extends SiftMerchantResponse> {
     private final String accountId;
     FieldSet fieldSet;
-    private OkHttpClient okClient;
+    private HttpClient httpClient;
     private HttpUrl baseUrl;
 
     protected abstract HttpUrl path(HttpUrl baseUrl);
@@ -26,10 +26,10 @@ public abstract class SiftMerchantRequest<T extends SiftMerchantResponse> {
         return path(baseUrl);
     }
 
-    SiftMerchantRequest(HttpUrl baseUrl, String accountId, OkHttpClient okClient, FieldSet fields) {
+    SiftMerchantRequest(HttpUrl baseUrl, String accountId, HttpClient httpClient, FieldSet fields) {
         this.baseUrl = baseUrl;
         this.accountId = accountId;
-        this.okClient = okClient;
+        this.httpClient = httpClient;
         this.fieldSet = fields;
     }
 
@@ -50,7 +50,7 @@ public abstract class SiftMerchantRequest<T extends SiftMerchantResponse> {
             new Request.Builder().addHeader("User-Agent", USER_AGENT_HEADER).url(this.url());
         modifyRequestBuilder(okRequestBuilder);
         Request request = okRequestBuilder.build();
-        T response = buildResponse(OkHttpUtils.execute(request, okClient), fieldSet);
+        T response = buildResponse(httpClient.execute(request), fieldSet);
 
         if (!response.isOk()) {
             throw new MerchantAPIException(response.getApiErrorMessage());

--- a/src/main/java/com/siftscience/SiftMerchantRequest.java
+++ b/src/main/java/com/siftscience/SiftMerchantRequest.java
@@ -1,6 +1,7 @@
 package com.siftscience;
 
 import com.siftscience.exception.MerchantAPIException;
+import com.siftscience.utils.OkHttpUtils;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -45,13 +46,14 @@ public abstract class SiftMerchantRequest<T extends SiftMerchantResponse> {
     public T send() throws IOException {
         fieldSet.validate();
 
-        Request.Builder okRequestBuilder = new Request.Builder().addHeader("User-Agent", USER_AGENT_HEADER).url(this.url());
+        Request.Builder okRequestBuilder =
+            new Request.Builder().addHeader("User-Agent", USER_AGENT_HEADER).url(this.url());
         modifyRequestBuilder(okRequestBuilder);
         Request request = okRequestBuilder.build();
-        T response = buildResponse(okClient.newCall(request).execute(), fieldSet);
+        T response = buildResponse(OkHttpUtils.execute(request, okClient), fieldSet);
 
         if (!response.isOk()) {
-                throw new MerchantAPIException(response.getApiErrorMessage());
+            throw new MerchantAPIException(response.getApiErrorMessage());
         }
 
         return response;

--- a/src/main/java/com/siftscience/SiftRequest.java
+++ b/src/main/java/com/siftscience/SiftRequest.java
@@ -1,12 +1,21 @@
 package com.siftscience;
 
-import com.siftscience.exception.*;
-import com.siftscience.utils.OkHttpUtils;
-import okhttp3.*;
-
 import java.io.IOException;
 
 import static com.siftscience.Constants.USER_AGENT_HEADER;
+import com.siftscience.exception.InvalidApiKeyException;
+import com.siftscience.exception.InvalidFieldException;
+import com.siftscience.exception.InvalidRequestException;
+import com.siftscience.exception.MissingFieldException;
+import com.siftscience.exception.RateLimitException;
+import com.siftscience.exception.ServerException;
+import com.siftscience.exception.SiftException;
+import com.siftscience.utils.OkHttpUtils;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
 
 /**
  * SiftRequest is the base class for all Sift API requests. It implements the `send` method which
@@ -15,7 +24,7 @@ import static com.siftscience.Constants.USER_AGENT_HEADER;
 public abstract class SiftRequest<T extends SiftResponse> {
     private final String accountId;
     FieldSet fieldSet;
-    private OkHttpClient okClient;
+    private HttpClient httpClient;
     private HttpUrl baseUrl;
 
     protected abstract HttpUrl path(HttpUrl baseUrl);
@@ -24,10 +33,10 @@ public abstract class SiftRequest<T extends SiftResponse> {
         return path(baseUrl);
     }
 
-    SiftRequest(HttpUrl baseUrl, String accountId, OkHttpClient okClient, FieldSet fields) {
+    SiftRequest(HttpUrl baseUrl, String accountId, HttpClient httpClient, FieldSet fields) {
         this.baseUrl = baseUrl;
         this.accountId = accountId;
-        this.okClient = okClient;
+        this.httpClient = httpClient;
         this.fieldSet = fields;
     }
 
@@ -47,7 +56,7 @@ public abstract class SiftRequest<T extends SiftResponse> {
         Request.Builder okRequestBuilder = new Request.Builder().addHeader("User-Agent", USER_AGENT_HEADER).url(this.url());
         modifyRequestBuilder(okRequestBuilder);
         Request request = okRequestBuilder.build();
-        T response = buildResponse(OkHttpUtils.execute(request, okClient), fieldSet);
+        T response = buildResponse(httpClient.execute(request), fieldSet);
 
         // If not successful but no exception happened yet, dig deeper into the response so we
         // can manually throw an appropriate exception.

--- a/src/main/java/com/siftscience/SiftRequest.java
+++ b/src/main/java/com/siftscience/SiftRequest.java
@@ -1,6 +1,7 @@
 package com.siftscience;
 
 import com.siftscience.exception.*;
+import com.siftscience.utils.OkHttpUtils;
 import okhttp3.*;
 
 import java.io.IOException;
@@ -46,7 +47,7 @@ public abstract class SiftRequest<T extends SiftResponse> {
         Request.Builder okRequestBuilder = new Request.Builder().addHeader("User-Agent", USER_AGENT_HEADER).url(this.url());
         modifyRequestBuilder(okRequestBuilder);
         Request request = okRequestBuilder.build();
-        T response = buildResponse(okClient.newCall(request).execute(), fieldSet);
+        T response = buildResponse(OkHttpUtils.execute(request, okClient), fieldSet);
 
         // If not successful but no exception happened yet, dig deeper into the response so we
         // can manually throw an appropriate exception.

--- a/src/main/java/com/siftscience/UnlabelRequest.java
+++ b/src/main/java/com/siftscience/UnlabelRequest.java
@@ -10,9 +10,9 @@ import java.io.IOException;
  * https://siftscience.com/developers/docs/curl/labels-api/unlabel-user
  */
 public class UnlabelRequest extends SiftRequest<UnlabelResponse> {
-    UnlabelRequest(HttpUrl baseUrl, String accountId, OkHttpClient okClient,
+    UnlabelRequest(HttpUrl baseUrl, String accountId, HttpClient httpClient,
                    UnlabelFieldSet fields) {
-        super(baseUrl, accountId, okClient, fields);
+        super(baseUrl, accountId, httpClient, fields);
     }
 
     /**

--- a/src/main/java/com/siftscience/UpdateMerchantRequest.java
+++ b/src/main/java/com/siftscience/UpdateMerchantRequest.java
@@ -16,8 +16,8 @@ public class UpdateMerchantRequest extends SiftMerchantRequest<UpdateMerchantRes
 
     private final String merchantId;
 
-    UpdateMerchantRequest(HttpUrl baseUrl, String accountId, OkHttpClient okClient, FieldSet fields, String merchantId) {
-        super(baseUrl, accountId, okClient, fields);
+    UpdateMerchantRequest(HttpUrl baseUrl, String accountId, HttpClient httpClient, FieldSet fields, String merchantId) {
+        super(baseUrl, accountId, httpClient, fields);
         this.merchantId = merchantId;
     }
 

--- a/src/main/java/com/siftscience/UserScoreRequest.java
+++ b/src/main/java/com/siftscience/UserScoreRequest.java
@@ -1,13 +1,12 @@
 package com.siftscience;
 
+import java.io.IOException;
+
 import com.siftscience.model.UserScoreFieldSet;
 import okhttp3.HttpUrl;
-import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-
-import java.io.IOException;
 
 /**
  * UserScoreRequest is the request type of Sift User Score API requests.
@@ -19,9 +18,9 @@ import java.io.IOException;
  *    See details here: https://siftscience.com/developers/docs/java/score-api/rescore
  */
 public class UserScoreRequest extends SiftRequest<EntityScoreResponse> {
-    UserScoreRequest(HttpUrl baseUrl, String accountId, OkHttpClient okClient,
+    UserScoreRequest(HttpUrl baseUrl, String accountId, HttpClient httpClient,
                      UserScoreFieldSet fields) {
-        super(baseUrl, accountId, okClient, fields);
+        super(baseUrl, accountId, httpClient, fields);
     }
 
     /**

--- a/src/main/java/com/siftscience/VerificationCheckRequest.java
+++ b/src/main/java/com/siftscience/VerificationCheckRequest.java
@@ -1,15 +1,14 @@
 package com.siftscience;
 
-import com.siftscience.model.VerificationCheckFieldSet;
-import okhttp3.OkHttpClient;
-import okhttp3.HttpUrl;
-import okhttp3.Response;
-import okhttp3.Request;
-import okhttp3.Credentials;
-import okhttp3.MediaType;
-import okhttp3.RequestBody;
-
 import java.io.IOException;
+
+import com.siftscience.model.VerificationCheckFieldSet;
+import okhttp3.Credentials;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
 
 
 /**
@@ -18,8 +17,8 @@ import java.io.IOException;
 */
 public class VerificationCheckRequest extends SiftRequest<VerificationCheckResponse> {
 
-    VerificationCheckRequest(HttpUrl baseUrl, String accountId, OkHttpClient okClient, VerificationCheckFieldSet fields) {
-        super(baseUrl, accountId, okClient, fields);
+    VerificationCheckRequest(HttpUrl baseUrl, String accountId, HttpClient httpClient, VerificationCheckFieldSet fields) {
+        super(baseUrl, accountId, httpClient, fields);
     }
 
     @Override

--- a/src/main/java/com/siftscience/VerificationResendRequest.java
+++ b/src/main/java/com/siftscience/VerificationResendRequest.java
@@ -1,15 +1,14 @@
 package com.siftscience;
 
-import com.siftscience.model.VerificationResendFieldSet;
-import okhttp3.OkHttpClient;
-import okhttp3.HttpUrl;
-import okhttp3.Response;
-import okhttp3.Request;
-import okhttp3.Credentials;
-import okhttp3.MediaType;
-import okhttp3.RequestBody;
-
 import java.io.IOException;
+
+import com.siftscience.model.VerificationResendFieldSet;
+import okhttp3.Credentials;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
 
 /**
 * The resend call generates a new OTP and sends it to the original recipient with the same settings.
@@ -17,8 +16,8 @@ import java.io.IOException;
 * */
 public class VerificationResendRequest extends SiftRequest<VerificationResendResponse> {
 
-    VerificationResendRequest(HttpUrl baseUrl, String accountId, OkHttpClient okClient, VerificationResendFieldSet fields) {
-        super(baseUrl, accountId, okClient, fields);
+    VerificationResendRequest(HttpUrl baseUrl, String accountId, HttpClient httpClient, VerificationResendFieldSet fields) {
+        super(baseUrl, accountId, httpClient, fields);
     }
 
     @Override

--- a/src/main/java/com/siftscience/VerificationSendRequest.java
+++ b/src/main/java/com/siftscience/VerificationSendRequest.java
@@ -1,15 +1,14 @@
 package com.siftscience;
 
-import com.siftscience.model.VerificationSendFieldSet;
-import okhttp3.OkHttpClient;
-import okhttp3.HttpUrl;
-import okhttp3.Response;
-import okhttp3.Request;
-import okhttp3.Credentials;
-import okhttp3.MediaType;
-import okhttp3.RequestBody;
-
 import java.io.IOException;
+
+import com.siftscience.model.VerificationSendFieldSet;
+import okhttp3.Credentials;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
 
 /**
 *The send call triggers the generation of an OTP code that is stored by Sift
@@ -18,8 +17,8 @@ import java.io.IOException;
 * */
 public class VerificationSendRequest  extends SiftRequest<VerificationSendResponse> {
 
-    VerificationSendRequest(HttpUrl baseUrl, String accountId, OkHttpClient okClient, VerificationSendFieldSet fields) {
-        super(baseUrl, accountId, okClient, fields);
+    VerificationSendRequest(HttpUrl baseUrl, String accountId, HttpClient httpClient, VerificationSendFieldSet fields) {
+        super(baseUrl, accountId, httpClient, fields);
     }
 
     @Override

--- a/src/main/java/com/siftscience/WorkflowStatusRequest.java
+++ b/src/main/java/com/siftscience/WorkflowStatusRequest.java
@@ -1,14 +1,16 @@
 package com.siftscience;
 
-import com.siftscience.model.WorkflowStatus;
-import com.siftscience.model.WorkflowStatusFieldSet;
-import okhttp3.*;
-
 import java.io.IOException;
 
+import com.siftscience.model.WorkflowStatusFieldSet;
+import okhttp3.Credentials;
+import okhttp3.HttpUrl;
+import okhttp3.Request;
+import okhttp3.Response;
+
 public class WorkflowStatusRequest extends SiftRequest<WorkflowStatusResponse> {
-    WorkflowStatusRequest(HttpUrl baseUrl, String accountId, OkHttpClient okClient, FieldSet fields) {
-        super(baseUrl, accountId, okClient, fields);
+    WorkflowStatusRequest(HttpUrl baseUrl, String accountId, HttpClient httpClient, FieldSet fields) {
+        super(baseUrl, accountId, httpClient, fields);
     }
 
     @Override

--- a/src/main/java/com/siftscience/utils/OkHttpUtils.java
+++ b/src/main/java/com/siftscience/utils/OkHttpUtils.java
@@ -22,7 +22,8 @@ public class OkHttpUtils {
      * which causes java.net.SocketTimeoutException from HTTP/2 connection to leave dead okhttp
      * clients in pool.
      * This utility method is used as a
-     * <a href="https://github.com/square/okhttp/issues/3146#issuecomment-1469679373">workaround</a>
+     * <a href="https://github.com/androidx/media/commit/80928e730c53729d147264a910fb327ba88be257">
+     * workaround</a>
      * to enqueue and sync wait for response
      *
      * @param request  - request to send
@@ -45,7 +46,9 @@ public class OkHttpUtils {
         try {
             return result.get();
         } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
+            // Intentionally don't interrupt, as it causes okHHtp fail as described
+            // in the link in javadoc
+            // Thread.currentThread().interrupt();
             result.cancel(true);
             throw new InterruptedIOException("Interrupted while waiting for reply from Sift");
         } catch (ExecutionException e) {

--- a/src/main/java/com/siftscience/utils/OkHttpUtils.java
+++ b/src/main/java/com/siftscience/utils/OkHttpUtils.java
@@ -1,0 +1,57 @@
+package com.siftscience.utils;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.siftscience.exception.SiftException;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.jetbrains.annotations.NotNull;
+
+public class OkHttpUtils {
+
+    private static final int DEFAULT_TIMEOUT_SEC = 30;
+
+    /**
+     * There is a <a href="https://github.com/square/okhttp/issues/7841">bug</a> on okHttp library,
+     * which causes java.net.SocketTimeoutException from HTTP/2 connection to leave dead okhttp
+     * clients in pool.
+     * This utility method is used as a
+     * <a href="https://github.com/square/okhttp/issues/3146#issuecomment-1469679373">workaround</a>
+     * to enqueue and sync wait for response
+     *
+     * @param request  - request to send
+     * @param okClient - client library
+     * @return - response
+     */
+    public static Response execute(Request request, OkHttpClient okClient) {
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        AtomicReference<Response> response = new AtomicReference<>();
+        okClient.newCall(request).enqueue(new Callback() {
+            @Override
+            public void onFailure(@NotNull Call call, @NotNull IOException e) {
+                throw new SiftException(e.getMessage());
+            }
+
+            @Override
+            public void onResponse(@NotNull Call call, @NotNull Response httpResponse) {
+                response.set(httpResponse);
+                countDownLatch.countDown();
+            }
+        });
+        try {
+            if (countDownLatch.await(DEFAULT_TIMEOUT_SEC, TimeUnit.SECONDS)) {
+                return response.get();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new SiftException("Interrupted while waiting for reply from Sift");
+        }
+        throw new SiftException("Timeout while waiting for reply from Sift");
+    }
+}

--- a/src/test/java/com/siftscience/SiftRequestTest.java
+++ b/src/test/java/com/siftscience/SiftRequestTest.java
@@ -37,7 +37,7 @@ public class SiftRequestTest {
 
         // Verify the request.
         RecordedRequest recordedRequest = server.takeRequest();
-        Assert.assertEquals("SiftScience/v205 sift-java/3.14.1", recordedRequest.getHeader("User-Agent"));
+        Assert.assertEquals("SiftScience/v205 sift-java/3.14.2", recordedRequest.getHeader("User-Agent"));
     }
 
 }

--- a/src/test/java/com/siftscience/SiftRequestTest.java
+++ b/src/test/java/com/siftscience/SiftRequestTest.java
@@ -40,4 +40,31 @@ public class SiftRequestTest {
         Assert.assertEquals("SiftScience/v205 sift-java/3.14.2", recordedRequest.getHeader("User-Agent"));
     }
 
+    @Test
+    public void testEnqueueRequests() throws Exception {
+        MockWebServer server = new MockWebServer();
+        MockResponse response = new MockResponse();
+        response.setResponseCode(HTTP_OK);
+
+        server.enqueue(response);
+        server.start();
+
+        // Create a new client and link it to the mock server.
+        SiftClient client = new SiftClient("YOUR_API_KEY", "YOUR_ACCOUNT_ID",
+            new OkHttpClient.Builder()
+                .addInterceptor(OkHttpUtils.urlRewritingInterceptor(server))
+                .build());
+        client.enqueueRequests();
+
+        // Build and execute the request against the mock server.
+        ApplyDecisionRequest request = client.buildRequest(
+            new ApplyDecisionFieldSet()
+                .setUserId("a_user_id")
+                .setTime(System.currentTimeMillis()));
+
+        ApplyDecisionResponse receivedResponse = request.send();
+
+        // verify
+        Assert.assertNotNull(receivedResponse);
+    }
 }


### PR DESCRIPTION
## Purpose
Our customer experiences SocketTimeoutException with sift-java. 
Overall it looks like this is still an [open issue](https://github.com/square/okhttp/issues/7841) with okhttp.

## Technical details
[Seems](https://github.com/square/okhttp/issues/3146#issuecomment-1469679373), When using Call.execute() which is synchronous, the actual initial request processing including writing to the HTTP/2 socket is done on the calling thread, so an interrupt leaves the HTTP/2 connection in an inconsistent state.

[Workarounds](https://github.com/square/okhttp/issues/3146#issuecomment-276449485):
1. set the connectionPool in the builder so it uses a new connection pool w/ a size of zero 
2. turn off HTTP/2 support by setting a new protocolList in the builder with only HTTP/1.1 support. 

Another [workaround](https://github.com/square/okhttp/issues/3146#issuecomment-1469679373) with [implementation](https://github.com/androidx/media/commit/80928e730c53729d147264a910fb327ba88be257) proposed - 
always use enqueue, even to simulate an execute so the thread writing the underlying socket is never a user thread that can be interrupted.

Seems this is the most optimal fix, and will be implemented in this PR.
With the current fix `siftClient. enqueueRequests()` will use `enqueue` instead of `execute`






