### PR TITLE
[PAY-5294] - Add support for $wager event type

### DIFF
--- a/CHANGES.MD
+++ b/CHANGES.MD
@@ -1,6 +1,9 @@
 3.17.0 (2024-11-15)
 =================
-- Added support for `$wager` event type
+- Added support for `$wager` event type in Events API
+- Added support for `$minimum_deposit_amount`, `$maximum_deposit_amount`,
+  `$minimum_withdrawal_amount`, `$maximum_withdrawal_amount`, `$current_balance`,
+  and `$new_balance` fields to `$transaction` events
   
 3.16.0 (2024-09-26)
 =================

--- a/CHANGES.MD
+++ b/CHANGES.MD
@@ -1,3 +1,7 @@
+3.17.0 (2024-11-15)
+=================
+- Added support for `$wager` event type
+  
 3.16.0 (2024-09-26)
 =================
 - Added support for `$iata_carrier_code` to the `$booking` complex field

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Java 1.7 or later.
 <dependency>
     <groupId>com.siftscience</groupId>
     <artifactId>sift-java</artifactId>
-    <version>3.16.0</version>
+    <version>3.17.0</version>
 </dependency>
 ```
 ### Gradle
 ```
 dependencies {
-    compile 'com.siftscience:sift-java:3.16.0'
+    compile 'com.siftscience:sift-java:3.17.0'
 }
 ```
 ### Other

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'signing'
 apply plugin: 'java-library-distribution'
 
 group = 'com.siftscience'
-version = '3.16.0'
+version = '3.17.0'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/siftscience/Constants.java
+++ b/src/main/java/com/siftscience/Constants.java
@@ -3,6 +3,6 @@ package com.siftscience;
 public class Constants {
 
     public static final String API_VERSION = "v205";
-    public static final String LIB_VERSION = "3.16.0";
+    public static final String LIB_VERSION = "3.17.0";
     public static final String USER_AGENT_HEADER = String.format("SiftScience/%s sift-java/%s", API_VERSION, LIB_VERSION);
 }

--- a/src/main/java/com/siftscience/model/TransactionFieldSet.java
+++ b/src/main/java/com/siftscience/model/TransactionFieldSet.java
@@ -31,6 +31,12 @@ public class TransactionFieldSet extends BaseAppBrowserSiteBrandFieldSet<Transac
     @Expose @SerializedName("$digital_orders") private List<DigitalOrder> digitalOrders;
     @Expose @SerializedName("$receiver_wallet_address") private String receiverWalletAddress;
     @Expose @SerializedName("$receiver_external_address") private Boolean receiverExternalAddress;
+    @Expose @SerializedName("$minimum_deposit_amount") private Long minimumDepositAmount;
+    @Expose @SerializedName("$maximum_deposit_amount") private Long maximumDepositAmount;
+    @Expose @SerializedName("$minimum_withdrawal_amount") private Long minimumWithdrawalAmount;
+    @Expose @SerializedName("$maximum_withdrawal_amount") private Long maximumWithdrawalAmount;
+    @Expose @SerializedName("$current_balance") private Long currentBalance;
+    @Expose @SerializedName("$new_balance") private Long newBalance;
 
 
     @Override
@@ -256,6 +262,60 @@ public class TransactionFieldSet extends BaseAppBrowserSiteBrandFieldSet<Transac
 
     public TransactionFieldSet setReceiverExternalAddress(Boolean receiverExternalAddress) {
         this.receiverExternalAddress = receiverExternalAddress;
+        return this;
+    }
+
+    public Long getMinimumDepositAmount() {
+        return minimumDepositAmount;
+    }
+
+    public TransactionFieldSet setMinimumDepositAmount(Long minimumDepositAmount) {
+        this.minimumDepositAmount = minimumDepositAmount;
+        return this;
+    }
+
+    public Long getMaximumDepositAmount() {
+        return maximumDepositAmount;
+    }
+
+    public TransactionFieldSet setMaximumDepositAmount(Long maximumDepositAmount) {
+        this.maximumDepositAmount = maximumDepositAmount;
+        return this;
+    }
+
+    public Long getMinimumWithdrawalAmount() {
+        return minimumWithdrawalAmount;
+    }
+
+    public TransactionFieldSet setMinimumWithdrawalAmount(Long minimumWithdrawalAmount) {
+        this.minimumWithdrawalAmount = minimumWithdrawalAmount;
+        return this;
+    }
+
+    public Long getMaximumWithdrawalAmount() {
+        return maximumWithdrawalAmount;
+    }
+
+    public TransactionFieldSet setMaximumWithdrawalAmount(Long maximumWithdrawalAmount) {
+        this.maximumWithdrawalAmount = maximumWithdrawalAmount;
+        return this;
+    }
+
+    public Long getCurrentBalance() {
+        return currentBalance;
+    }
+
+    public TransactionFieldSet setCurrentBalance(Long currentBalance) {
+        this.currentBalance = currentBalance;
+        return this;
+    }
+
+    public Long getNewBalance() {
+        return newBalance;
+    }
+
+    public TransactionFieldSet setNewBalance(Long newBalance) {
+        this.newBalance = newBalance;
         return this;
     }
 }

--- a/src/main/java/com/siftscience/model/WagerFieldSet.java
+++ b/src/main/java/com/siftscience/model/WagerFieldSet.java
@@ -1,0 +1,107 @@
+package com.siftscience.model;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+public class WagerFieldSet  extends EventsApiRequestFieldSet<WagerFieldSet> {
+
+    @Expose @SerializedName("$wager_id") private String wagerId;
+    @Expose @SerializedName("$wager_type") private String wagerType;
+    @Expose @SerializedName("$wager_status") private String wagerStatus;
+    @Expose @SerializedName("$amount") private Long amount;
+    @Expose @SerializedName("$currency_code") private String currencyCode;
+    @Expose @SerializedName("$wager_event_type") private String wagerEventType;
+    @Expose @SerializedName("$wager_event_name") private String wagerEventName;
+    @Expose @SerializedName("$wager_event_id") private String wagerEventId;
+    @Expose @SerializedName("$minimum_wager_amount") private Long minimumWagerAmount;
+
+    @Override
+    public String getEventType() {
+        return "$wager";
+    }
+
+    public static WagerFieldSet fromJson(String json) {
+        return gson.fromJson(json, WagerFieldSet.class);
+    }
+
+    public String getWagerId() {
+        return wagerId;
+    }
+
+    public WagerFieldSet setWagerId(String wagerId) {
+        this.wagerId = wagerId;
+        return this;
+    }
+
+    public String getWagerType() {
+        return wagerType;
+    }
+
+    public WagerFieldSet setWagerType(String wagerType) {
+        this.wagerType = wagerType;
+        return this;
+    }
+
+    public String getWagerStatus() {
+        return wagerStatus;
+    }
+
+    public WagerFieldSet setWagerStatus(String wagerStatus) {
+        this.wagerStatus = wagerStatus;
+        return this;
+    }
+
+    public Long getAmount() {
+        return amount;
+    }
+
+    public WagerFieldSet setAmount(Long amount) {
+        this.amount = amount;
+        return this;
+    }
+
+    public String getCurrencyCode() {
+        return currencyCode;
+    }
+
+    public WagerFieldSet setCurrencyCode(String currencyCode) {
+        this.currencyCode = currencyCode;
+        return this;
+    }
+
+    public String getWagerEventType() {
+        return wagerEventType;
+    }
+
+    public WagerFieldSet setWagerEventType(String wagerEventType) {
+        this.wagerEventType = wagerEventType;
+        return this;
+    }
+
+    public String getWagerEventName() {
+        return wagerEventName;
+    }
+
+    public WagerFieldSet setWagerEventName(String wagerEventName) {
+        this.wagerEventName = wagerEventName;
+        return this;
+    }
+
+    public String getWagerEventId() {
+        return wagerEventId;
+    }
+
+    public WagerFieldSet setWagerEventId(String wagerEventId) {
+        this.wagerEventId = wagerEventId;
+        return this;
+    }
+
+    public Long getMinimumWagerAmount() {
+        return minimumWagerAmount;
+    }
+
+    public WagerFieldSet setMinimumWagerAmount(Long minimumWagerAmount) {
+        this.minimumWagerAmount = minimumWagerAmount;
+        return this;
+    }
+}

--- a/src/test/java/com/siftscience/SiftRequestTest.java
+++ b/src/test/java/com/siftscience/SiftRequestTest.java
@@ -37,7 +37,7 @@ public class SiftRequestTest {
 
         // Verify the request.
         RecordedRequest recordedRequest = server.takeRequest();
-        Assert.assertEquals("SiftScience/v205 sift-java/3.16.0", recordedRequest.getHeader("User-Agent"));
+        Assert.assertEquals("SiftScience/v205 sift-java/3.17.0", recordedRequest.getHeader("User-Agent"));
     }
 
     @Test

--- a/src/test/java/com/siftscience/TransactionEventTest.java
+++ b/src/test/java/com/siftscience/TransactionEventTest.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.siftscience.model.DigitalOrder;
-import com.siftscience.model.PaymentMethod;
 import com.siftscience.model.TransactionFieldSet;
 import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockResponse;

--- a/src/test/java/com/siftscience/TransactionEventTest.java
+++ b/src/test/java/com/siftscience/TransactionEventTest.java
@@ -666,4 +666,132 @@ public class TransactionEventTest {
 
         server.shutdown();
     }
+
+    @Test
+    public void testTransactionEventWithExtraDepositFields() throws Exception {
+        String expectedRequestBody = "{\n" +
+            "  \"$type\"                   : \"$transaction\",\n" +
+            "  \"$api_key\"                : \"YOUR_API_KEY\",\n" +
+            "  \"$user_id\"                : \"billy_jones_301\",\n" +
+            "  \"$amount\"                 : 500000,\n" +
+            "  \"$currency_code\"          : \"USD\",\n" +
+            "  \"$transaction_type\"       : \"$deposit\",\n" +
+            "  \"$transaction_id\"         : \"719637215\",\n" +
+            "  \"$minimum_deposit_amount\" : 5000,\n" +
+            "  \"$maximum_deposit_amount\" : 100000000,\n" +
+            "  \"$current_balance\"        : 500000,\n" +
+            "  \"$new_balance\"            : 1000000,\n" +
+            "}";
+
+        // Start a new mock server and enqueue a mock response.
+        MockWebServer server = new MockWebServer();
+        MockResponse response = new MockResponse();
+        response.setResponseCode(HTTP_OK);
+        response.setBody("{\n" +
+            "    \"status\" : 0,\n" +
+            "    \"error_message\" : \"OK\",\n" +
+            "    \"time\" : 1327604222,\n" +
+            "    \"request\" : \"" + TestUtils.unescapeJson(expectedRequestBody) + "\"\n" +
+            "}");
+        server.enqueue(response);
+        server.start();
+
+        // Create a new client and link it to the mock server.
+        SiftClient client = new SiftClient("YOUR_API_KEY", "YOUR_ACCOUNT_ID",
+            new OkHttpClient.Builder()
+                .addInterceptor(OkHttpUtils.urlRewritingInterceptor(server))
+                .build());
+
+        // Build and execute the request against the mock server.
+        EventRequest request = client.buildRequest(new TransactionFieldSet()
+            .setUserId("billy_jones_301")
+            .setAmount(500000L)
+            .setCurrencyCode("USD")
+            .setTransactionType("$deposit")
+            .setTransactionId("719637215")
+            .setMinimumDepositAmount(5000L)
+            .setMaximumDepositAmount(100000000L)
+            .setCurrentBalance(500000L)
+            .setNewBalance(1000000L));
+
+        EventResponse siftResponse = request.send();
+
+        // Verify the request.
+        RecordedRequest request1 = server.takeRequest();
+        Assert.assertEquals("POST", request1.getMethod());
+        Assert.assertEquals("/v205/events", request1.getPath());
+        JSONAssert.assertEquals(expectedRequestBody, request.getFieldSet().toJson(), true);
+
+        // Verify the response.
+        Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
+        Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
+        JSONAssert.assertEquals(response.getBody().readUtf8(),
+            siftResponse.getBody().toJson(), true);
+
+        server.shutdown();
+    }
+
+    @Test
+    public void testTransactionEventWithExtraWithdrawalFields() throws Exception {
+        String expectedRequestBody = "{\n" +
+            "  \"$type\"                      : \"$transaction\",\n" +
+            "  \"$api_key\"                   : \"YOUR_API_KEY\",\n" +
+            "  \"$user_id\"                   : \"billy_jones_301\",\n" +
+            "  \"$amount\"                    : 500000,\n" +
+            "  \"$currency_code\"             : \"USD\",\n" +
+            "  \"$transaction_type\"          : \"$withdrawal\",\n" +
+            "  \"$transaction_id\"            : \"719637215\",\n" +
+            "  \"$minimum_withdrawal_amount\" : 5000,\n" +
+            "  \"$maximum_withdrawal_amount\" : 100000000,\n" +
+            "  \"$current_balance\"           : 1000000,\n" +
+            "  \"$new_balance\"               : 500000,\n" +
+            "}";
+
+        // Start a new mock server and enqueue a mock response.
+        MockWebServer server = new MockWebServer();
+        MockResponse response = new MockResponse();
+        response.setResponseCode(HTTP_OK);
+        response.setBody("{\n" +
+            "    \"status\" : 0,\n" +
+            "    \"error_message\" : \"OK\",\n" +
+            "    \"time\" : 1327604222,\n" +
+            "    \"request\" : \"" + TestUtils.unescapeJson(expectedRequestBody) + "\"\n" +
+            "}");
+        server.enqueue(response);
+        server.start();
+
+        // Create a new client and link it to the mock server.
+        SiftClient client = new SiftClient("YOUR_API_KEY", "YOUR_ACCOUNT_ID",
+            new OkHttpClient.Builder()
+                .addInterceptor(OkHttpUtils.urlRewritingInterceptor(server))
+                .build());
+
+        // Build and execute the request against the mock server.
+        EventRequest request = client.buildRequest(new TransactionFieldSet()
+            .setUserId("billy_jones_301")
+            .setAmount(500000L)
+            .setCurrencyCode("USD")
+            .setTransactionType("$withdrawal")
+            .setTransactionId("719637215")
+            .setMinimumWithdrawalAmount(5000L)
+            .setMaximumWithdrawalAmount(100000000L)
+            .setCurrentBalance(1000000L)
+            .setNewBalance(500000L));
+
+        EventResponse siftResponse = request.send();
+
+        // Verify the request.
+        RecordedRequest request1 = server.takeRequest();
+        Assert.assertEquals("POST", request1.getMethod());
+        Assert.assertEquals("/v205/events", request1.getPath());
+        JSONAssert.assertEquals(expectedRequestBody, request.getFieldSet().toJson(), true);
+
+        // Verify the response.
+        Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
+        Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
+        JSONAssert.assertEquals(response.getBody().readUtf8(),
+            siftResponse.getBody().toJson(), true);
+
+        server.shutdown();
+    }
 }

--- a/src/test/java/com/siftscience/WagerFieldSetTest.java
+++ b/src/test/java/com/siftscience/WagerFieldSetTest.java
@@ -1,0 +1,78 @@
+package com.siftscience;
+
+import static java.net.HttpURLConnection.HTTP_OK;
+
+import com.siftscience.model.WagerFieldSet;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+public class WagerFieldSetTest {
+    @Test
+    public void testWagerEvent() throws Exception {
+        String expectedRequestBody = "{\n" +
+            "  \"$type\"                 : \"$wager\",\n" +
+            "  \"$api_key\"              : \"YOUR_API_KEY\",\n" +
+            "  \"$user_id\"              : \"billy_jones_301\",\n" +
+            "  \"$wager_id\"             : \"wager_id_123\",\n" +
+            "  \"$wager_type\"           : \"win_1\",\n" +
+            "  \"$wager_status\"         : \"$accept\",\n" +
+            "  \"$amount\"               : 506790000,\n" +
+            "  \"$currency_code\"        : \"USD\",\n" +
+            "  \"$wager_event_type\"     : \"sportsbook\",\n" +
+            "  \"$wager_event_name\"     : \"NFL\",\n" +
+            "  \"$wager_event_id\"       : \"NFL_2024_N1234\",\n" +
+            "  \"$minimum_wager_amount\" : 1000000,\n" +
+            "}";
+
+        // Start a new mock server and enqueue a mock response.
+        MockWebServer server = new MockWebServer();
+        MockResponse response = new MockResponse();
+        response.setResponseCode(HTTP_OK);
+        response.setBody("{\n" +
+            "    \"status\" : 0,\n" +
+            "    \"error_message\" : \"OK\",\n" +
+            "    \"time\" : 1327604222,\n" +
+            "    \"request\" : \"" + TestUtils.unescapeJson(expectedRequestBody) + "\"\n" +
+            "}");
+        server.enqueue(response);
+        server.start();
+
+        // Create a new client and link it to the mock server.
+        SiftClient client = new SiftClient("YOUR_API_KEY", "YOUR_ACCOUNT_ID",
+            new OkHttpClient.Builder()
+                .addInterceptor(OkHttpUtils.urlRewritingInterceptor(server))
+                .build());
+
+        // Build and execute the request against the mock server.
+        EventRequest request = client.buildRequest(new WagerFieldSet()
+            .setUserId("billy_jones_301")
+            .setWagerId("wager_id_123")
+            .setWagerType("win_1")
+            .setWagerStatus("$accept")
+            .setAmount(506790000L)
+            .setCurrencyCode("USD")
+            .setWagerEventType("sportsbook")
+            .setWagerEventName("NFL")
+            .setWagerEventId("NFL_2024_N1234")
+            .setMinimumWagerAmount(1000000L));
+        EventResponse siftResponse = request.send();
+
+        // Verify the request.
+        RecordedRequest request1 = server.takeRequest();
+        Assert.assertEquals("POST", request1.getMethod());
+        Assert.assertEquals("/v205/events", request1.getPath());
+        JSONAssert.assertEquals(expectedRequestBody, request.getFieldSet().toJson(), true);
+
+        // Verify the response.
+        Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
+        Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
+        JSONAssert.assertEquals(response.getBody().readUtf8(),
+            siftResponse.getBody().toJson(), true);
+        server.shutdown();
+    }
+}


### PR DESCRIPTION
Jira: https://sift.atlassian.net/browse/PAY-5294

Rest API PR: https://github.com/SiftScience/code/pull/59305

Added support for `$wager` event type at Event API.
Added support for 6 new fields at `$transaction` event