### PR TITLE
[API-8040, API-7676]: Error handling and input validation improvements

### DIFF
--- a/src/main/java/com/siftscience/exception/SiftException.java
+++ b/src/main/java/com/siftscience/exception/SiftException.java
@@ -19,8 +19,10 @@ public class SiftException extends RuntimeException {
     }
 
     private static String responseErrorMessage(SiftResponse response) {
-        if (response == null || response.getApiErrorMessage() == null) {
+        if (response == null) {
             return "Unexpected API error.";
+        } else if (response.getApiErrorMessage() == null) {
+            return "Unexpected API error " + response.getHttpStatusCode() + ".";
         }
         return response.getApiErrorMessage();
     }

--- a/src/test/java/com/siftscience/SiftClientTest.java
+++ b/src/test/java/com/siftscience/SiftClientTest.java
@@ -4,6 +4,8 @@ import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import java.io.IOException;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import com.siftscience.exception.InvalidApiKeyException;
 import com.siftscience.exception.InvalidFieldException;
 import com.siftscience.exception.MissingFieldException;
@@ -15,7 +17,6 @@ import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.json.JSONException;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -93,11 +94,11 @@ public class SiftClientTest {
         }
 
         // We should have gotten an exception.
-        Assert.assertNotNull(apiKeyException);
-        Assert.assertEquals("Invalid API key message.", apiKeyException.getLocalizedMessage());
+        assertNotNull(apiKeyException);
+        assertEquals("Invalid API key message.", apiKeyException.getLocalizedMessage());
 
         // Check that we can access the API key from the exception object.
-        Assert.assertEquals("INVALID_API_KEY",
+        assertEquals("INVALID_API_KEY",
                 apiKeyException.getSiftResponse().getRequestBody().getApiKey());
     }
 
@@ -141,8 +142,8 @@ public class SiftClientTest {
         }
 
         // We should have gotten an exception.
-        Assert.assertNotNull(missingFieldException);
-        Assert.assertEquals("Missing user email message from server.",
+        assertNotNull(missingFieldException);
+        assertEquals("Missing user email message from server.",
                 missingFieldException.getLocalizedMessage());
     }
 
@@ -164,8 +165,8 @@ public class SiftClientTest {
         }
 
         // Should have thrown an exception.
-        Assert.assertNotNull(invalidFieldException);
-        Assert.assertEquals("Custom field \"$not_allowed\" may not begin with a dollar sign.",
+        assertNotNull(invalidFieldException);
+        assertEquals("Custom field \"$not_allowed\" may not begin with a dollar sign.",
                 invalidFieldException.getLocalizedMessage());
     }
 
@@ -211,8 +212,8 @@ public class SiftClientTest {
         }
 
         // We should have gotten an exception.
-        Assert.assertNotNull(rateLimitException);
-        Assert.assertEquals("Rate limit error message.", rateLimitException.getLocalizedMessage());
+        assertNotNull(rateLimitException);
+        assertEquals("Rate limit error message.", rateLimitException.getLocalizedMessage());
     }
 
     /**
@@ -243,8 +244,9 @@ public class SiftClientTest {
         }
 
         // We should have gotten an exception.
-        Assert.assertNotNull(serverException);
-        Assert.assertEquals("Unexpected API error.", serverException.getLocalizedMessage());
+        assertNotNull(serverException);
+        assertEquals("Unexpected API error " + HTTP_INTERNAL_ERROR + ".",
+            serverException.getLocalizedMessage());
     }
 
     /**
@@ -276,8 +278,9 @@ public class SiftClientTest {
         }
 
         // We should have gotten an exception.
-        Assert.assertNotNull(serverException);
-        Assert.assertEquals("Unexpected API error.", serverException.getLocalizedMessage());
+        assertNotNull(serverException);
+        assertEquals("Unexpected API error " + HTTP_INTERNAL_ERROR + ".",
+            serverException.getLocalizedMessage());
     }
 
     /**

--- a/src/test/java/com/siftscience/SiftRequestTest.java
+++ b/src/test/java/com/siftscience/SiftRequestTest.java
@@ -1,54 +1,72 @@
 package com.siftscience;
 
+import static java.net.HttpURLConnection.HTTP_BAD_GATEWAY;
+import static java.net.HttpURLConnection.HTTP_OK;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import com.siftscience.exception.SiftException;
 import com.siftscience.model.ApplyDecisionFieldSet;
 import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
-import org.junit.Assert;
 import org.junit.Test;
-import static java.net.HttpURLConnection.HTTP_OK;
 
 public class SiftRequestTest {
 
     @Test
     public void testUserAgentHeader() throws Exception {
+        // given
         MockWebServer server = new MockWebServer();
-        MockResponse response = new MockResponse();
-        response.setResponseCode(HTTP_OK);
+        setUpMockResponseWithCode(server, HTTP_OK);
+        ApplyDecisionRequest request = createRequest(server, "a_user_id");
 
-        server.enqueue(response);
-        server.start();
-        String userId = "a_user_id";
-
-        // Create a new client and link it to the mock server.
-        SiftClient client = new SiftClient("YOUR_API_KEY", "YOUR_ACCOUNT_ID",
-                new OkHttpClient.Builder()
-                        .addInterceptor(OkHttpUtils.urlRewritingInterceptor(server))
-                        .build());
-
-        // Build and execute the request against the mock server.
-        ApplyDecisionRequest request = client.buildRequest(
-                new ApplyDecisionFieldSet()
-                        .setUserId(userId)
-                        .setTime(System.currentTimeMillis()));
-
+        // when
         request.send();
 
-        // Verify the request.
+        // then
         RecordedRequest recordedRequest = server.takeRequest();
-        Assert.assertEquals("SiftScience/v205 sift-java/3.17.0", recordedRequest.getHeader("User-Agent"));
+        assertEquals("SiftScience/v205 sift-java/3.17.0",
+            recordedRequest.getHeader("User-Agent"));
     }
 
     @Test
     public void testEnqueueRequests() throws Exception {
+        // given
         MockWebServer server = new MockWebServer();
-        MockResponse response = new MockResponse();
-        response.setResponseCode(HTTP_OK);
+        setUpMockResponseWithCode(server, HTTP_OK);
+        ApplyDecisionRequest request = createRequest(server, "a_user_id");
 
-        server.enqueue(response);
-        server.start();
+        // when
+        ApplyDecisionResponse receivedResponse = request.send();
 
+        // then
+        assertNotNull(receivedResponse);
+    }
+
+    @Test
+    public void testThrowsExceptionWhenReceivedServerError() throws Exception {
+        // given
+        MockWebServer server = new MockWebServer();
+        setUpMockResponseWithCode(server, HTTP_BAD_GATEWAY);
+        ApplyDecisionRequest request = createRequest(server, "a_user_id");
+
+        // when
+        try {
+            request.send();
+            fail("request.send() is expected to throw SiftException");
+        } catch (SiftException siftException) {
+
+            // then
+            assertEquals("Unexpected API error " + HTTP_BAD_GATEWAY + ".",
+                siftException.getMessage());
+        }
+    }
+
+    private ApplyDecisionRequest createRequest(MockWebServer server, String userId) {
         // Create a new client and link it to the mock server.
         SiftClient client = new SiftClient("YOUR_API_KEY", "YOUR_ACCOUNT_ID",
             new OkHttpClient.Builder()
@@ -57,14 +75,17 @@ public class SiftRequestTest {
         client.enqueueRequests();
 
         // Build and execute the request against the mock server.
-        ApplyDecisionRequest request = client.buildRequest(
+        return client.buildRequest(
             new ApplyDecisionFieldSet()
-                .setUserId("a_user_id")
+                .setUserId(userId)
                 .setTime(System.currentTimeMillis()));
+    }
 
-        ApplyDecisionResponse receivedResponse = request.send();
+    private void setUpMockResponseWithCode(MockWebServer server, int httpCode) throws IOException {
+        MockResponse response = new MockResponse();
+        response.setResponseCode(httpCode);
 
-        // verify
-        Assert.assertNotNull(receivedResponse);
+        server.enqueue(response);
+        server.start();
     }
 }


### PR DESCRIPTION
**Purpose:**
- https://sift.atlassian.net/browse/API-8040
- https://sift.atlassian.net/browse/API-7676

**Tech details:**
- Include HTTP status code in response message for Sift exception
- Sift Java SDK to fail when initialised with null api key or Http client 
- Sift Java SDK to fail when building events with null Account ID (in case accountID is required for that event)