### PR TITLE
[PAY-5624] - Support for $exchange_rete field in Events API

### DIFF
--- a/CHANGES.MD
+++ b/CHANGES.MD
@@ -1,3 +1,8 @@
+3.19.0 (2025-04-24)
+=================
+- Added support for `$exchange_rate` complex field to `$transaction`, `$create_order`,
+  `$update_order` and `$wager` events, `$booking`, `$discount` and `$item` event fields 
+
 3.18.0 (2025-03-28)
 =================
 - Added support for `$card_bin_metadata` complex field to `$payment_method`

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Java 1.7 or later.
 <dependency>
     <groupId>com.siftscience</groupId>
     <artifactId>sift-java</artifactId>
-    <version>3.18.0</version>
+    <version>3.19.0</version>
 </dependency>
 ```
 ### Gradle
 ```
 dependencies {
-    compile 'com.siftscience:sift-java:3.18.0'
+    compile 'com.siftscience:sift-java:3.19.0'
 }
 ```
 ### Other

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'signing'
 apply plugin: 'java-library-distribution'
 
 group = 'com.siftscience'
-version = '3.18.0'
+version = '3.19.0'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/siftscience/Constants.java
+++ b/src/main/java/com/siftscience/Constants.java
@@ -3,6 +3,6 @@ package com.siftscience;
 public class Constants {
 
     public static final String API_VERSION = "v205";
-    public static final String LIB_VERSION = "3.18.0";
+    public static final String LIB_VERSION = "3.19.0";
     public static final String USER_AGENT_HEADER = String.format("SiftScience/%s sift-java/%s", API_VERSION, LIB_VERSION);
 }

--- a/src/main/java/com/siftscience/model/BaseOrderFieldSet.java
+++ b/src/main/java/com/siftscience/model/BaseOrderFieldSet.java
@@ -11,6 +11,7 @@ public abstract class BaseOrderFieldSet<T extends BaseOrderFieldSet<T>>
     @Expose @SerializedName(USER_EMAIL) private String userEmail;
     @Expose @SerializedName("$amount") private Long amount;
     @Expose @SerializedName("$currency_code") private String currencyCode;
+    @Expose @SerializedName("$exchange_rate") private ExchangeRate exchangeRate;
     @Expose @SerializedName("$billing_address") private Address billingAddress;
     @Expose @SerializedName("$shipping_address") private Address shippingAddress;
     @Expose @SerializedName("$payment_methods") private List<PaymentMethod> paymentMethods;
@@ -60,6 +61,15 @@ public abstract class BaseOrderFieldSet<T extends BaseOrderFieldSet<T>>
 
     public T setCurrencyCode(String currencyCode) {
         this.currencyCode = currencyCode;
+        return (T) this;
+    }
+
+    public ExchangeRate getExchangeRate() {
+        return exchangeRate;
+    }
+
+    public T setExchangeRate(ExchangeRate exchangeRate) {
+        this.exchangeRate = exchangeRate;
         return (T) this;
     }
 

--- a/src/main/java/com/siftscience/model/Booking.java
+++ b/src/main/java/com/siftscience/model/Booking.java
@@ -12,6 +12,7 @@ public class Booking {
     @Expose @SerializedName("$end_time") private Long endTime;
     @Expose @SerializedName("$price") private Long price;
     @Expose @SerializedName("$currency_code") private String currencyCode;
+    @Expose @SerializedName("$exchange_rate") private ExchangeRate exchangeRate;
     @Expose @SerializedName("$quantity") private Long quantity;
     @Expose @SerializedName("$iata_carrier_code") private String iataCarrierCode;
     @Expose @SerializedName("$guests") private List<Guest> guests;
@@ -74,6 +75,15 @@ public class Booking {
 
     public Booking setCurrencyCode(String currencyCode) {
         this.currencyCode = currencyCode;
+        return this;
+    }
+
+    public ExchangeRate getExchangeRate() {
+        return exchangeRate;
+    }
+
+    public Booking setExchangeRate(ExchangeRate exchangeRate) {
+        this.exchangeRate = exchangeRate;
         return this;
     }
 

--- a/src/main/java/com/siftscience/model/Discount.java
+++ b/src/main/java/com/siftscience/model/Discount.java
@@ -7,6 +7,7 @@ public class Discount {
     @Expose @SerializedName("$percentage_off") private Double percentageOff;
     @Expose @SerializedName("$amount") private Long amount;
     @Expose @SerializedName("$currency_code") private String currencyCode;
+    @Expose @SerializedName("$exchange_rate") private ExchangeRate exchangeRate;
     @Expose @SerializedName("$minimum_purchase_amount") private Long minimumPurchaseAmount;
 
     public Double getPercentageOff() {
@@ -33,6 +34,15 @@ public class Discount {
 
     public Discount setCurrencyCode(String currencyCode) {
         this.currencyCode = currencyCode;
+        return this;
+    }
+
+    public ExchangeRate getExchangeRate() {
+        return exchangeRate;
+    }
+
+    public Discount setExchangeRate(ExchangeRate exchangeRate) {
+        this.exchangeRate = exchangeRate;
         return this;
     }
 

--- a/src/main/java/com/siftscience/model/ExchangeRate.java
+++ b/src/main/java/com/siftscience/model/ExchangeRate.java
@@ -1,0 +1,27 @@
+package com.siftscience.model;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+public class ExchangeRate {
+    @Expose @SerializedName("$quote_currency_code") private String quoteCurrencyCode;
+    @Expose @SerializedName("$rate") private Float rate;
+
+    public String getQuoteCurrencyCode() {
+        return quoteCurrencyCode;
+    }
+
+    public ExchangeRate setQuoteCurrencyCode(String quoteCurrencyCode) {
+        this.quoteCurrencyCode = quoteCurrencyCode;
+        return this;
+    }
+
+    public Float getRate() {
+        return rate;
+    }
+
+    public ExchangeRate setRate(Float rate) {
+        this.rate = rate;
+        return this;
+    }
+}

--- a/src/main/java/com/siftscience/model/Item.java
+++ b/src/main/java/com/siftscience/model/Item.java
@@ -10,6 +10,7 @@ public class Item {
     @Expose @SerializedName("$product_title") private String productTitle;
     @Expose @SerializedName("$price") private Long price;
     @Expose @SerializedName("$currency_code") private String currencyCode;
+    @Expose @SerializedName("$exchange_rate") private ExchangeRate exchangeRate;
     @Expose @SerializedName("$quantity") private Long quantity;
     @Expose @SerializedName("$upc") private String upc;
     @Expose @SerializedName("$sku") private String sku;
@@ -68,6 +69,15 @@ public class Item {
 
     public String getCurrencyCode() {
         return currencyCode;
+    }
+
+    public ExchangeRate getExchangeRate() {
+        return exchangeRate;
+    }
+
+    public Item setExchangeRate(ExchangeRate exchangeRate) {
+        this.exchangeRate = exchangeRate;
+        return this;
     }
 
     public Item setCurrencyCode(String currencyCode) {

--- a/src/main/java/com/siftscience/model/TransactionFieldSet.java
+++ b/src/main/java/com/siftscience/model/TransactionFieldSet.java
@@ -8,6 +8,7 @@ import com.google.gson.annotations.SerializedName;
 public class TransactionFieldSet extends BaseAppBrowserSiteBrandFieldSet<TransactionFieldSet> {
     @Expose @SerializedName("$amount") private Long amount;
     @Expose @SerializedName("$currency_code") private String currencyCode;
+    @Expose @SerializedName("$exchange_rate") private ExchangeRate exchangeRate;
     @Expose @SerializedName(USER_EMAIL) private String userEmail;
     @Expose @SerializedName("$transaction_type") private String transactionType;
     @Expose @SerializedName("$transaction_status") private String transactionStatus;
@@ -63,6 +64,15 @@ public class TransactionFieldSet extends BaseAppBrowserSiteBrandFieldSet<Transac
 
     public TransactionFieldSet setCurrencyCode(String currencyCode) {
         this.currencyCode = currencyCode;
+        return this;
+    }
+
+    public ExchangeRate getExchangeRate() {
+        return exchangeRate;
+    }
+
+    public TransactionFieldSet setExchangeRate(ExchangeRate exchangeRate) {
+        this.exchangeRate = exchangeRate;
         return this;
     }
 

--- a/src/main/java/com/siftscience/model/WagerFieldSet.java
+++ b/src/main/java/com/siftscience/model/WagerFieldSet.java
@@ -10,6 +10,7 @@ public class WagerFieldSet  extends EventsApiRequestFieldSet<WagerFieldSet> {
     @Expose @SerializedName("$wager_status") private String wagerStatus;
     @Expose @SerializedName("$amount") private Long amount;
     @Expose @SerializedName("$currency_code") private String currencyCode;
+    @Expose @SerializedName("$exchange_rate") private ExchangeRate exchangeRate;
     @Expose @SerializedName("$wager_event_type") private String wagerEventType;
     @Expose @SerializedName("$wager_event_name") private String wagerEventName;
     @Expose @SerializedName("$wager_event_id") private String wagerEventId;
@@ -66,6 +67,15 @@ public class WagerFieldSet  extends EventsApiRequestFieldSet<WagerFieldSet> {
 
     public WagerFieldSet setCurrencyCode(String currencyCode) {
         this.currencyCode = currencyCode;
+        return this;
+    }
+
+    public ExchangeRate getExchangeRate() {
+        return exchangeRate;
+    }
+
+    public WagerFieldSet setExchangeRate(ExchangeRate exchangeRate) {
+        this.exchangeRate = exchangeRate;
         return this;
     }
 

--- a/src/test/java/com/siftscience/CreateOrderEventTest.java
+++ b/src/test/java/com/siftscience/CreateOrderEventTest.java
@@ -2,6 +2,7 @@ package com.siftscience;
 
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_OK;
+import static java.util.Collections.singletonList;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -11,6 +12,7 @@ import com.siftscience.exception.InvalidFieldException;
 import com.siftscience.model.Booking;
 import com.siftscience.model.CreateOrderFieldSet;
 import com.siftscience.model.DigitalOrder;
+import com.siftscience.model.ExchangeRate;
 import com.siftscience.model.Item;
 import com.siftscience.model.PaymentMethod;
 import com.siftscience.model.Promotion;
@@ -1028,6 +1030,116 @@ public class CreateOrderEventTest {
                 .setCurrencyCode("USD")
                 .setPaymentMethods(paymentMethodList)
                 .setDigitalOrders(digitalOrderList));
+
+        EventResponse siftResponse = request.send();
+
+        // Verify the request.
+        RecordedRequest request1 = server.takeRequest();
+        Assert.assertEquals("POST", request1.getMethod());
+        Assert.assertEquals("/v205/events", request1.getPath());
+        JSONAssert.assertEquals(expectedRequestBody, request.getFieldSet().toJson(), true);
+
+        // Verify the response.
+        Assert.assertEquals(HTTP_OK, siftResponse.getHttpStatusCode());
+        Assert.assertEquals(0, (int) siftResponse.getBody().getStatus());
+        JSONAssert.assertEquals(response.getBody().readUtf8(),
+            siftResponse.getBody().toJson(), true);
+
+        server.shutdown();
+    }
+
+    @Test
+    public void testCreateOrderEventWithExchangeRate() throws JSONException, IOException,
+        InterruptedException {
+
+        // The expected JSON payload of the request.
+        String expectedRequestBody = "{\n" +
+            "  \"$type\"          : \"$create_order\",\n" +
+            "  \"$api_key\"       : \"YOUR_API_KEY\",\n" +
+            "  \"$user_id\"       : \"billy_jones_301\",\n" +
+            "  \"$order_id\"      : \"ORDER-28168441\",\n" +
+            "  \"$amount\"        : 115940000,\n" +
+            "  \"$currency_code\" : \"EUR\",\n" +
+            "  \"$exchange_rate\" : {\n" +
+            "      \"$quote_currency_code\" : \"USD\",\n" +
+            "      \"$rate\"                : 1.15\n" +
+            "  },\n" +
+            "  \"$bookings\" : [\n" +
+            "    {\n" +
+            "      \"$price\"         : 49900000,\n" +
+            "      \"$currency_code\" : \"EUR\",\n" +
+            "      \"$exchange_rate\" : {\n" +
+            "          \"$quote_currency_code\" : \"USD\",\n" +
+            "          \"$rate\"                : 1.15\n" +
+            "      }\n" +
+            "    }\n" +
+            "  ],\n" +
+            "  \"$promotions\" : [\n" +
+            "    {\n" +
+            "      \"$discount\" : {\n" +
+            "        \"$amount\"        : 5000000,\n" +
+            "        \"$currency_code\" : \"EUR\",\n" +
+            "        \"$exchange_rate\" : {\n" +
+            "            \"$quote_currency_code\" : \"USD\",\n" +
+            "            \"$rate\"                : 1.15\n" +
+            "        }\n" +
+            "      }\n" +
+            "    }\n" +
+            "  ],\n" +
+            "  \"$items\" : [\n" +
+            "    {\n" +
+            "      \"$price\"         : 39990000,\n" +
+            "      \"$currency_code\" : \"EUR\",\n" +
+            "      \"$exchange_rate\" : {\n" +
+            "          \"$quote_currency_code\" : \"USD\",\n" +
+            "          \"$rate\"                : 1.15\n" +
+            "      }\n" +
+            "    }\n" +
+            "  ]\n" +
+            "}\n";
+
+        // Start a new mock server and enqueue a mock response.
+        MockWebServer server = new MockWebServer();
+        MockResponse response = new MockResponse();
+        response.setResponseCode(HTTP_OK);
+        response.setBody("{\n" +
+            "    \"status\" : 0,\n" +
+            "    \"error_message\" : \"OK\",\n" +
+            "    \"time\" : 1327604222,\n" +
+            "    \"request\" : \"" + TestUtils.unescapeJson(expectedRequestBody) + "\"\n" +
+            "}");
+        server.enqueue(response);
+        server.start();
+
+        // Create a new client and link it to the mock server.
+        SiftClient client = new SiftClient("YOUR_API_KEY", "YOUR_ACCOUNT_ID",
+            new OkHttpClient.Builder()
+                .addInterceptor(OkHttpUtils.urlRewritingInterceptor(server))
+                .build());
+
+        // Payment methods.
+        List<PaymentMethod> paymentMethodList = new ArrayList<>();
+        paymentMethodList.add(TestUtils.samplePaymentMethodWalletFields());
+
+        // Digital orders.
+        List<DigitalOrder> digitalOrderList = new ArrayList<>();
+        digitalOrderList.add(TestUtils.sampleDigitalOrder());
+
+        // Build and execute the request against the mock server.
+        // It includes booking, promotion and item with ExchangeRate
+        EventRequest request = client.buildRequest(
+            new CreateOrderFieldSet()
+                .setUserId("billy_jones_301")
+                .setOrderId("ORDER-28168441")
+                .setAmount(115940000L)
+                .setCurrencyCode("EUR")
+                .setExchangeRate(new ExchangeRate()
+                    .setQuoteCurrencyCode("USD")
+                    .setRate(1.15f))
+                .setBookings(singletonList(TestUtils.sampleBookingWithExchangeRate()))
+                .setPromotions(singletonList(TestUtils.samplePromotionWithExchangeRate()))
+                .setItems(singletonList(TestUtils.sampleItemWithExchangeRate()))
+        );
 
         EventResponse siftResponse = request.send();
 

--- a/src/test/java/com/siftscience/CreateOrderEventTest.java
+++ b/src/test/java/com/siftscience/CreateOrderEventTest.java
@@ -1117,14 +1117,6 @@ public class CreateOrderEventTest {
                 .addInterceptor(OkHttpUtils.urlRewritingInterceptor(server))
                 .build());
 
-        // Payment methods.
-        List<PaymentMethod> paymentMethodList = new ArrayList<>();
-        paymentMethodList.add(TestUtils.samplePaymentMethodWalletFields());
-
-        // Digital orders.
-        List<DigitalOrder> digitalOrderList = new ArrayList<>();
-        digitalOrderList.add(TestUtils.sampleDigitalOrder());
-
         // Build and execute the request against the mock server.
         // It includes booking, promotion and item with ExchangeRate
         EventRequest request = client.buildRequest(

--- a/src/test/java/com/siftscience/SiftRequestTest.java
+++ b/src/test/java/com/siftscience/SiftRequestTest.java
@@ -29,7 +29,7 @@ public class SiftRequestTest {
 
         // then
         RecordedRequest recordedRequest = server.takeRequest();
-        assertEquals("SiftScience/v205 sift-java/3.18.0",
+        assertEquals("SiftScience/v205 sift-java/3.19.0",
             recordedRequest.getHeader("User-Agent"));
     }
 

--- a/src/test/java/com/siftscience/TestUtils.java
+++ b/src/test/java/com/siftscience/TestUtils.java
@@ -5,6 +5,7 @@ import com.siftscience.model.Booking;
 import com.siftscience.model.CreditPoint;
 import com.siftscience.model.DigitalOrder;
 import com.siftscience.model.Discount;
+import com.siftscience.model.ExchangeRate;
 import com.siftscience.model.Guest;
 import com.siftscience.model.Item;
 import com.siftscience.model.MerchantProfile;
@@ -170,6 +171,15 @@ public class TestUtils {
                 .setQuantity(2L);
     }
 
+    static Item sampleItemWithExchangeRate() {
+        return new Item()
+            .setPrice(39990000L)
+            .setCurrencyCode("EUR")
+            .setExchangeRate(new ExchangeRate()
+                .setQuoteCurrencyCode("USD")
+                .setRate(1.15f));
+    }
+
     static Booking sampleBooking() {
         List<Guest> guests = new ArrayList<>();
         guests.add(sampleGuest1());
@@ -190,6 +200,15 @@ public class TestUtils {
             .setIataCarrierCode("AS")
             .setTags(sampleTags3())
             .setQuantity(1L);
+    }
+
+    static Booking sampleBookingWithExchangeRate() {
+        return new Booking()
+            .setPrice(49900000L)
+            .setCurrencyCode("EUR")
+            .setExchangeRate(new ExchangeRate()
+                .setQuoteCurrencyCode("USD")
+                .setRate(1.15f));
     }
 
     static OrderedFrom sampleOrderedFrom() {
@@ -239,6 +258,15 @@ public class TestUtils {
                 .setCurrencyCode("USD");
     }
 
+    static Discount sampleDiscountWithExchangeRate() {
+        return new Discount()
+            .setAmount(5000000L)
+            .setCurrencyCode("EUR")
+            .setExchangeRate(new ExchangeRate()
+                .setQuoteCurrencyCode("USD")
+                .setRate(1.15f));
+    }
+
     static CreditPoint sampleCreditPoint() {
         return new CreditPoint()
                 .setAmount(100L)
@@ -268,6 +296,11 @@ public class TestUtils {
                 .setDescription("$5 off your first 5 rides")
                 .setReferrerUserId("elon-m93903")
                 .setDiscount(sampleDiscount2());
+    }
+
+    static Promotion samplePromotionWithExchangeRate() {
+        return new Promotion()
+            .setDiscount(sampleDiscountWithExchangeRate());
     }
 
     static List<String> sampleCategories() {

--- a/src/test/java/com/siftscience/WagerFieldSetTest.java
+++ b/src/test/java/com/siftscience/WagerFieldSetTest.java
@@ -2,6 +2,7 @@ package com.siftscience;
 
 import static java.net.HttpURLConnection.HTTP_OK;
 
+import com.siftscience.model.ExchangeRate;
 import com.siftscience.model.WagerFieldSet;
 import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockResponse;
@@ -22,7 +23,11 @@ public class WagerFieldSetTest {
             "  \"$wager_type\"           : \"win_1\",\n" +
             "  \"$wager_status\"         : \"$accept\",\n" +
             "  \"$amount\"               : 506790000,\n" +
-            "  \"$currency_code\"        : \"USD\",\n" +
+            "  \"$currency_code\"        : \"EUR\",\n" +
+            "  \"$exchange_rate\"        : {\n" +
+            "      \"$quote_currency_code\" : \"USD\",\n" +
+            "      \"$rate\"                : 1.15\n" +
+            "  },\n" +
             "  \"$wager_event_type\"     : \"sportsbook\",\n" +
             "  \"$wager_event_name\"     : \"NFL\",\n" +
             "  \"$wager_event_id\"       : \"NFL_2024_N1234\",\n" +
@@ -55,7 +60,10 @@ public class WagerFieldSetTest {
             .setWagerType("win_1")
             .setWagerStatus("$accept")
             .setAmount(506790000L)
-            .setCurrencyCode("USD")
+            .setCurrencyCode("EUR")
+            .setExchangeRate(new ExchangeRate()
+                .setQuoteCurrencyCode("USD")
+                .setRate(1.15f))
             .setWagerEventType("sportsbook")
             .setWagerEventName("NFL")
             .setWagerEventId("NFL_2024_N1234")


### PR DESCRIPTION
Jira:
- https://sift.atlassian.net/browse/PAY-5624

Rest API PR: https://github.com/SiftScience/code/pull/60552

- Added support for the `$exchange_rate` complex field to the following event types and reserved event fields:
  - Transaction
  - Create/Update Order
  - Wager
  - Booking
  - Discount
  - Item